### PR TITLE
fix num qubits error

### DIFF
--- a/qiskit/aqua/algorithms/single_sample/amplitude_estimation/ae.py
+++ b/qiskit/aqua/algorithms/single_sample/amplitude_estimation/ae.py
@@ -87,9 +87,6 @@ class AmplitudeEstimation(AmplitudeEstimationBase):
         self._m = num_eval_qubits
         self._M = 2 ** num_eval_qubits
 
-        # determine number of ancillas
-        self._num_ancillas = self.q_factory.required_ancillas_controlled()
-        self._num_qubits = self.a_factory.num_target_qubits + self._m + self._num_ancillas
 
         if iqft is None:
             iqft = Standard(self._m)
@@ -128,6 +125,15 @@ class AmplitudeEstimation(AmplitudeEstimationBase):
             PluggableType.IQFT, iqft_params['name']).init_params(params)
 
         return cls(num_eval_qubits, uncertainty_problem, q_factory=None, iqft=iqft)
+
+    @property
+    def _num_qubits(self):
+        self.check_factories()  # ensure that A/Q factories are set
+
+        num_ancillas = self.q_factory.required_ancillas_controlled()
+        num_qubits = self.a_factory.num_target_qubits + self._m + num_ancillas
+
+        return num_qubits
 
     def construct_circuit(self, measurement=False):
         """


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
Fix `_num_qubits` not defined issue


### Details and comments
Since the A/Q factories can be set later now, the `_num_qubits` property must be a method (with property decorator, optionally) which checks if the factories have been set before computing the number of qubits.

