### PR TITLE
Fixed a bug of `decode` func of `IntegerToBinaryConverter`

### DIFF
--- a/qiskit/optimization/converters/integer_to_binary_converter.py
+++ b/qiskit/optimization/converters/integer_to_binary_converter.py
@@ -28,10 +28,9 @@ logger = logging.getLogger(__name__)
 _HAS_CPLEX = False
 try:
     from cplex import SparsePair
-
     _HAS_CPLEX = True
 except ImportError:
-    logger.info("CPLEX is not installed.")
+    logger.info('CPLEX is not installed.')
 
 
 class IntegerToBinaryConverter:
@@ -44,12 +43,12 @@ class IntegerToBinaryConverter:
         >>> problem2 = conv.encode(problem)
     """
 
-    _delimiter = "@"  # users are supposed not to use this character in variable names
+    _delimiter = '@'  # users are supposed not to use this character in variable names
 
     def __init__(self) -> None:
         """Initializes the internal data structure."""
         if not _HAS_CPLEX:
-            raise NameError("CPLEX is not installed.")
+            raise NameError('CPLEX is not installed.')
 
         self._src = None
         self._dst = None
@@ -203,7 +202,7 @@ class IntegerToBinaryConverter:
 
         # TODO: add quadratic constraints
         if self._src.quadratic_constraints.get_num() > 0:
-            raise QiskitOptimizationError("Quadratic constraints are not yet supported.")
+            raise QiskitOptimizationError('Quadratic constraints are not yet supported.')
 
     def decode(self, result: OptimizationResult) -> OptimizationResult:
         """Convert the encoded problem (binary variables) back to the original (integer variables).

--- a/qiskit/optimization/converters/integer_to_binary_converter.py
+++ b/qiskit/optimization/converters/integer_to_binary_converter.py
@@ -28,9 +28,10 @@ logger = logging.getLogger(__name__)
 _HAS_CPLEX = False
 try:
     from cplex import SparsePair
+
     _HAS_CPLEX = True
 except ImportError:
-    logger.info('CPLEX is not installed.')
+    logger.info("CPLEX is not installed.")
 
 
 class IntegerToBinaryConverter:
@@ -43,12 +44,12 @@ class IntegerToBinaryConverter:
         >>> problem2 = conv.encode(problem)
     """
 
-    _delimiter = '@'  # users are supposed not to use this character in variable names
+    _delimiter = "@"  # users are supposed not to use this character in variable names
 
     def __init__(self) -> None:
         """Initializes the internal data structure."""
         if not _HAS_CPLEX:
-            raise NameError('CPLEX is not installed.')
+            raise NameError("CPLEX is not installed.")
 
         self._src = None
         self._dst = None
@@ -81,16 +82,18 @@ class IntegerToBinaryConverter:
         upper_bounds = self._src.variables.get_upper_bounds()
         for i, variable in enumerate(names):
             typ = types[i]
-            if typ == 'I':
-                new_vars: List[Tuple[str, int]] = self._encode_var(name=variable,
-                                                                   lower_bound=lower_bounds[i],
-                                                                   upper_bound=upper_bounds[i])
+            if typ == "I":
+                new_vars: List[Tuple[str, int]] = self._encode_var(
+                    name=variable, lower_bound=lower_bounds[i], upper_bound=upper_bounds[i]
+                )
                 self._conv[variable] = new_vars
-                self._dst.variables.add(names=[new_name for new_name, _ in new_vars],
-                                        types='B' * len(new_vars))
+                self._dst.variables.add(
+                    names=[new_name for new_name, _ in new_vars], types="B" * len(new_vars)
+                )
             else:
-                self._dst.variables.add(names=[variable], types=typ,
-                                        lb=[lower_bounds[i]], ub=[upper_bounds[i]])
+                self._dst.variables.add(
+                    names=[variable], types=typ, lb=[lower_bounds[i]], ub=[upper_bounds[i]]
+                )
 
         self._substitute_int_var()
 
@@ -194,12 +197,13 @@ class IntegerToBinaryConverter:
 
             lin_expr.append(sparse_pair)
 
-        self._dst.linear_constraints.add(lin_expr, linear_sense, linear_rhs, linear_ranges,
-                                         linear_names)
+        self._dst.linear_constraints.add(
+            lin_expr, linear_sense, linear_rhs, linear_ranges, linear_names
+        )
 
         # TODO: add quadratic constraints
         if self._src.quadratic_constraints.get_num() > 0:
-            raise QiskitOptimizationError('Quadratic constraints are not yet supported.')
+            raise QiskitOptimizationError("Quadratic constraints are not yet supported.")
 
     def decode(self, result: OptimizationResult) -> OptimizationResult:
         """Convert the encoded problem (binary variables) back to the original (integer variables).
@@ -218,7 +222,7 @@ class IntegerToBinaryConverter:
 
     def _decode_var(self, names, vals) -> List[int]:
         # decode integer values
-        sol = {name: int(vals[i]) for i, name in enumerate(names)}
+        sol = {name: float(vals[i]) for i, name in enumerate(names)}
         new_vals = []
         for name in self._src.variables.get_names():
             if name in self._conv:

--- a/test/optimization/test_converters.py
+++ b/test/optimization/test_converters.py
@@ -38,7 +38,6 @@ logger = logging.getLogger(__name__)
 _HAS_CPLEX = False
 try:
     from cplex import SparsePair
-
     _HAS_CPLEX = True
 except ImportError:
     logger.info("CPLEX is not installed.")
@@ -66,7 +65,7 @@ class TestConverters(QiskitOptimizationTestCase):
     def setUp(self) -> None:
         super().setUp()
         if not _HAS_CPLEX:
-            self.skipTest("CPLEX is not installed.")
+            self.skipTest('CPLEX is not installed.')
 
     def test_empty_problem(self):
         """ Test empty problem """
@@ -86,62 +85,62 @@ class TestConverters(QiskitOptimizationTestCase):
         # Integer variable
         with self.assertRaises(QiskitOptimizationError):
             op = OptimizationProblem()
-            op.variables.add(names=["x"], types="I")
+            op.variables.add(names=['x'], types='I')
             conv = OptimizationProblemToOperator()
             _ = conv.encode(op)
         # Continuous variable
         with self.assertRaises(QiskitOptimizationError):
             op = OptimizationProblem()
-            op.variables.add(names=["x"], types="C")
+            op.variables.add(names=['x'], types='C')
             conv = OptimizationProblemToOperator()
             _ = conv.encode(op)
         # Semi-Continuous variable
         with self.assertRaises(QiskitOptimizationError):
             op = OptimizationProblem()
-            op.variables.add(names=["x"], types="S")
+            op.variables.add(names=['x'], types='S')
             conv = OptimizationProblemToOperator()
             _ = conv.encode(op)
         # Semi-Integer variable
         with self.assertRaises(QiskitOptimizationError):
             op = OptimizationProblem()
-            op.variables.add(names=["x"], types="N")
+            op.variables.add(names=['x'], types='N')
             conv = OptimizationProblemToOperator()
             _ = conv.encode(op)
         # validate the types of the variables for InequalityToEqualityConverter
         # Semi-Continuous variable
         with self.assertRaises(QiskitOptimizationError):
             op = OptimizationProblem()
-            op.variables.add(names=["x"], types="S")
+            op.variables.add(names=['x'], types='S')
             conv = InequalityToEqualityConverter()
             _ = conv.encode(op)
         # Semi-Integer variable
         with self.assertRaises(QiskitOptimizationError):
             op = OptimizationProblem()
-            op.variables.add(names=["x"], types="N")
+            op.variables.add(names=['x'], types='N')
             conv = InequalityToEqualityConverter()
             _ = conv.encode(op)
 
     def test_inequality_binary(self):
         """ Test InequalityToEqualityConverter with binary variables """
         op = OptimizationProblem()
-        op.variables.add(names=["x", "y", "z"], types="B" * 3)
+        op.variables.add(names=['x', 'y', 'z'], types='B' * 3)
         op.linear_constraints.add(
             lin_expr=[
-                SparsePair(ind=["x", "y"], val=[1, 1]),
-                SparsePair(ind=["y", "z"], val=[1, -1]),
-                SparsePair(ind=["z", "x"], val=[1, 2]),
+                SparsePair(ind=['x', 'y'], val=[1, 1]),
+                SparsePair(ind=['y', 'z'], val=[1, -1]),
+                SparsePair(ind=['z', 'x'], val=[1, 2]),
             ],
-            senses=["E", "L", "G"],
+            senses=['E', 'L', 'G'],
             rhs=[1, 2, 3],
-            names=["xy", "yz", "zx"],
+            names=['xy', 'yz', 'zx'],
         )
         conv = InequalityToEqualityConverter()
         op2 = conv.encode(op)
         self.assertEqual(op.get_problem_name(), op2.get_problem_name())
         self.assertEqual(op.get_problem_type(), op2.get_problem_type())
         cst = op2.linear_constraints
-        self.assertListEqual(cst.get_names(), ["xy", "yz", "zx"])
-        self.assertListEqual(cst.get_senses(), ["E", "E", "E"])
+        self.assertListEqual(cst.get_names(), ['xy', 'yz', 'zx'])
+        self.assertListEqual(cst.get_senses(), ['E', 'E', 'E'])
         self.assertListEqual(cst.get_rhs(), [1, 2, 3])
         var = op2.variables
         self.assertListEqual(var.get_lower_bounds(3, 4), [0, 0])
@@ -150,24 +149,24 @@ class TestConverters(QiskitOptimizationTestCase):
     def test_inequality_integer(self):
         """ Test InequalityToEqualityConverter with integer variables """
         op = OptimizationProblem()
-        op.variables.add(names=["x", "y", "z"], types="I" * 3, lb=[-3] * 3, ub=[3] * 3)
+        op.variables.add(names=['x', 'y', 'z'], types='I' * 3, lb=[-3] * 3, ub=[3] * 3)
         op.linear_constraints.add(
             lin_expr=[
-                SparsePair(ind=["x", "y"], val=[1, 1]),
-                SparsePair(ind=["y", "z"], val=[1, -1]),
-                SparsePair(ind=["z", "x"], val=[1, 2]),
+                SparsePair(ind=['x', 'y'], val=[1, 1]),
+                SparsePair(ind=['y', 'z'], val=[1, -1]),
+                SparsePair(ind=['z', 'x'], val=[1, 2]),
             ],
-            senses=["E", "L", "G"],
+            senses=['E', 'L', 'G'],
             rhs=[1, 2, 3],
-            names=["xy", "yz", "zx"],
+            names=['xy', 'yz', 'zx'],
         )
         conv = InequalityToEqualityConverter()
         op2 = conv.encode(op)
         self.assertEqual(op.get_problem_name(), op2.get_problem_name())
         self.assertEqual(op.get_problem_type(), op2.get_problem_type())
         cst = op2.linear_constraints
-        self.assertListEqual(cst.get_names(), ["xy", "yz", "zx"])
-        self.assertListEqual(cst.get_senses(), ["E", "E", "E"])
+        self.assertListEqual(cst.get_names(), ['xy', 'yz', 'zx'])
+        self.assertListEqual(cst.get_senses(), ['E', 'E', 'E'])
         self.assertListEqual(cst.get_rhs(), [1, 2, 3])
         var = op2.variables
         self.assertListEqual(var.get_lower_bounds(3, 4), [0, 0])
@@ -176,73 +175,73 @@ class TestConverters(QiskitOptimizationTestCase):
     def test_inequality_mode_integer(self):
         """ Test integer mode of InequalityToEqualityConverter() """
         op = OptimizationProblem()
-        op.variables.add(names=["x", "y", "z"], types="B" * 3)
+        op.variables.add(names=['x', 'y', 'z'], types='B' * 3)
         op.linear_constraints.add(
             lin_expr=[
-                SparsePair(ind=["x", "y"], val=[1, 1]),
-                SparsePair(ind=["y", "z"], val=[1, -1]),
-                SparsePair(ind=["z", "x"], val=[1, 2]),
+                SparsePair(ind=['x', 'y'], val=[1, 1]),
+                SparsePair(ind=['y', 'z'], val=[1, -1]),
+                SparsePair(ind=['z', 'x'], val=[1, 2]),
             ],
-            senses=["E", "L", "G"],
+            senses=['E', 'L', 'G'],
             rhs=[1, 2, 3],
-            names=["xy", "yz", "zx"],
+            names=['xy', 'yz', 'zx'],
         )
         conv = InequalityToEqualityConverter()
-        op2 = conv.encode(op, mode="integer")
+        op2 = conv.encode(op, mode='integer')
         var = op2.variables
-        self.assertListEqual(var.get_types(3, 4), ["I", "I"])
+        self.assertListEqual(var.get_types(3, 4), ['I', 'I'])
 
     def test_inequality_mode_continuous(self):
         """ Test continuous mode of InequalityToEqualityConverter() """
         op = OptimizationProblem()
-        op.variables.add(names=["x", "y", "z"], types="B" * 3)
+        op.variables.add(names=['x', 'y', 'z'], types='B' * 3)
         op.linear_constraints.add(
             lin_expr=[
-                SparsePair(ind=["x", "y"], val=[1, 1]),
-                SparsePair(ind=["y", "z"], val=[1, -1]),
-                SparsePair(ind=["z", "x"], val=[1, 2]),
+                SparsePair(ind=['x', 'y'], val=[1, 1]),
+                SparsePair(ind=['y', 'z'], val=[1, -1]),
+                SparsePair(ind=['z', 'x'], val=[1, 2]),
             ],
-            senses=["E", "L", "G"],
+            senses=['E', 'L', 'G'],
             rhs=[1, 2, 3],
-            names=["xy", "yz", "zx"],
+            names=['xy', 'yz', 'zx'],
         )
         conv = InequalityToEqualityConverter()
-        op2 = conv.encode(op, mode="continuous")
+        op2 = conv.encode(op, mode='continuous')
         var = op2.variables
-        self.assertListEqual(var.get_types(3, 4), ["C", "C"])
+        self.assertListEqual(var.get_types(3, 4), ['C', 'C'])
 
     def test_inequality_mode_auto(self):
         """ Test auto mode of InequalityToEqualityConverter() """
         op = OptimizationProblem()
-        op.variables.add(names=["x", "y", "z"], types="B" * 3)
+        op.variables.add(names=['x', 'y', 'z'], types='B' * 3)
         op.linear_constraints.add(
             lin_expr=[
-                SparsePair(ind=["x", "y"], val=[1, 1]),
-                SparsePair(ind=["y", "z"], val=[1, -1]),
-                SparsePair(ind=["z", "x"], val=[1.1, 2.2]),
+                SparsePair(ind=['x', 'y'], val=[1, 1]),
+                SparsePair(ind=['y', 'z'], val=[1, -1]),
+                SparsePair(ind=['z', 'x'], val=[1.1, 2.2]),
             ],
-            senses=["E", "L", "G"],
+            senses=['E', 'L', 'G'],
             rhs=[1, 2, 3.3],
-            names=["xy", "yz", "zx"],
+            names=['xy', 'yz', 'zx'],
         )
         conv = InequalityToEqualityConverter()
-        op2 = conv.encode(op, mode="auto")
+        op2 = conv.encode(op, mode='auto')
         var = op2.variables
-        self.assertListEqual(var.get_types(3, 4), ["I", "C"])
+        self.assertListEqual(var.get_types(3, 4), ['I', 'C'])
 
     def test_penalize_sense(self):
         """ Test PenalizeLinearEqualityConstraints with senses """
         op = OptimizationProblem()
-        op.variables.add(names=["x", "y", "z"], types="B" * 3)
+        op.variables.add(names=['x', 'y', 'z'], types='B' * 3)
         op.linear_constraints.add(
             lin_expr=[
-                SparsePair(ind=["x", "y"], val=[1, 1]),
-                SparsePair(ind=["y", "z"], val=[1, -1]),
-                SparsePair(ind=["z", "x"], val=[1, 2]),
+                SparsePair(ind=['x', 'y'], val=[1, 1]),
+                SparsePair(ind=['y', 'z'], val=[1, -1]),
+                SparsePair(ind=['z', 'x'], val=[1, 2]),
             ],
-            senses=["E", "L", "G"],
+            senses=['E', 'L', 'G'],
             rhs=[1, 2, 3],
-            names=["xy", "yz", "zx"],
+            names=['xy', 'yz', 'zx'],
         )
         self.assertEqual(op.linear_constraints.get_num(), 3)
         conv = PenalizeLinearEqualityConstraints()
@@ -252,15 +251,15 @@ class TestConverters(QiskitOptimizationTestCase):
     def test_penalize_binary(self):
         """ Test PenalizeLinearEqualityConstraints with binary variables """
         op = OptimizationProblem()
-        op.variables.add(names=["x", "y", "z"], types="B" * 3)
+        op.variables.add(names=['x', 'y', 'z'], types='B' * 3)
         op.linear_constraints.add(
             lin_expr=[
-                SparsePair(ind=["x", "y"], val=[1, 1]),
-                SparsePair(ind=["y", "z"], val=[1, -1]),
+                SparsePair(ind=['x', 'y'], val=[1, 1]),
+                SparsePair(ind=['y', 'z'], val=[1, -1]),
             ],
-            senses=["E", "E"],
+            senses=['E', 'E'],
             rhs=[1, 2],
-            names=["xy", "yz"],
+            names=['xy', 'yz'],
         )
         self.assertEqual(op.linear_constraints.get_num(), 2)
         conv = PenalizeLinearEqualityConstraints()
@@ -270,15 +269,15 @@ class TestConverters(QiskitOptimizationTestCase):
     def test_penalize_integer(self):
         """ Test PenalizeLinearEqualityConstraints with integer variables """
         op = OptimizationProblem()
-        op.variables.add(names=["x", "y", "z"], types="I" * 3, lb=[-3] * 3, ub=[3] * 3)
+        op.variables.add(names=['x', 'y', 'z'], types='I' * 3, lb=[-3] * 3, ub=[3] * 3)
         op.linear_constraints.add(
             lin_expr=[
-                SparsePair(ind=["x", "y"], val=[1, 1]),
-                SparsePair(ind=["y", "z"], val=[1, -1]),
+                SparsePair(ind=['x', 'y'], val=[1, 1]),
+                SparsePair(ind=['y', 'z'], val=[1, -1]),
             ],
-            senses=["E", "E"],
+            senses=['E', 'E'],
             rhs=[1, 2],
-            names=["xy", "yz"],
+            names=['xy', 'yz'],
         )
         self.assertEqual(op.linear_constraints.get_num(), 2)
         conv = PenalizeLinearEqualityConstraints()
@@ -288,41 +287,41 @@ class TestConverters(QiskitOptimizationTestCase):
     def test_integer_to_binary(self):
         """ Test integer to binary """
         op = OptimizationProblem()
-        op.variables.add(names=["x", "y", "z"], types="BIC", lb=[0, 0, 0], ub=[1, 6, 10])
-        op.objective.set_linear([("x", 1), ("y", 2), ("z", 1)])
+        op.variables.add(names=['x', 'y', 'z'], types='BIC', lb=[0, 0, 0], ub=[1, 6, 10])
+        op.objective.set_linear([('x', 1), ('y', 2), ('z', 1)])
         op.linear_constraints.add(
-            lin_expr=[SparsePair(ind=["x", "y", "z"], val=[1, 3, 1])],
-            senses=["L"],
+            lin_expr=[SparsePair(ind=['x', 'y', 'z'], val=[1, 3, 1])],
+            senses=['L'],
             rhs=[10],
-            names=["xyz"],
+            names=['xyz'],
         )
         self.assertEqual(op.variables.get_num(), 3)
         conv = IntegerToBinaryConverter()
         op2 = conv.encode(op)
         names = op2.variables.get_names()
-        self.assertIn("x", names)
-        self.assertIn("z", names)
+        self.assertIn('x', names)
+        self.assertIn('z', names)
         variables = op2.variables
-        self.assertEqual(variables.get_lower_bounds("x"), 0.0)
-        self.assertEqual(variables.get_lower_bounds("z"), 0.0)
-        self.assertEqual(variables.get_upper_bounds("x"), 1.0)
-        self.assertEqual(variables.get_upper_bounds("z"), 10.0)
+        self.assertEqual(variables.get_lower_bounds('x'), 0.0)
+        self.assertEqual(variables.get_lower_bounds('z'), 0.0)
+        self.assertEqual(variables.get_upper_bounds('x'), 1.0)
+        self.assertEqual(variables.get_upper_bounds('z'), 10.0)
         self.assertListEqual(
-            variables.get_types(["x", "y@0", "y@1", "y@2", "z"]), ["B", "B", "B", "B", "C"]
+            variables.get_types(['x', 'y@0', 'y@1', 'y@2', 'z']), ['B', 'B', 'B', 'B', 'C']
         )
-        self.assertListEqual(op2.objective.get_linear(["y@0", "y@1", "y@2"]), [2, 4, 6])
+        self.assertListEqual(op2.objective.get_linear(['y@0', 'y@1', 'y@2']), [2, 4, 6])
         self.assertListEqual(op2.linear_constraints.get_rows()[0].val, [1, 3, 6, 9, 1])
 
     def test_binary_to_integer(self):
         """ Test binary to integer """
         op = OptimizationProblem()
-        op.variables.add(names=["x", "y", "z"], types="BIB", lb=[0, 0, 0], ub=[1, 7, 1])
-        op.objective.set_linear([("x", 2), ("y", 1), ("z", 1)])
+        op.variables.add(names=['x', 'y', 'z'], types='BIB', lb=[0, 0, 0], ub=[1, 7, 1])
+        op.objective.set_linear([('x', 2), ('y', 1), ('z', 1)])
         op.linear_constraints.add(
-            lin_expr=[SparsePair(ind=["x", "y", "z"], val=[1, 1, 1])],
-            senses=["L"],
+            lin_expr=[SparsePair(ind=['x', 'y', 'z'], val=[1, 1, 1])],
+            senses=['L'],
             rhs=[7],
-            names=["xyz"],
+            names=['xyz'],
         )
         op.objective.set_sense(-1)
         conv = IntegerToBinaryConverter()
@@ -335,13 +334,13 @@ class TestConverters(QiskitOptimizationTestCase):
     def test_optimizationproblem_to_operator(self):
         """ Test optimization problem to operators"""
         op = OptimizationProblem()
-        op.variables.add(names=["a", "b", "c", "d"], types="B" * 4)
-        op.objective.set_linear([("a", 1), ("b", 1), ("c", 1), ("d", 1)])
+        op.variables.add(names=['a', 'b', 'c', 'd'], types='B' * 4)
+        op.objective.set_linear([('a', 1), ('b', 1), ('c', 1), ('d', 1)])
         op.linear_constraints.add(
-            lin_expr=[SparsePair(ind=["a", "b", "c", "d"], val=[1, 2, 3, 4])],
-            senses=["E"],
+            lin_expr=[SparsePair(ind=['a', 'b', 'c', 'd'], val=[1, 2, 3, 4])],
+            senses=['E'],
             rhs=[3],
-            names=["abcd"],
+            names=['abcd'],
         )
         op.objective.set_sense(-1)
         penalize = PenalizeLinearEqualityConstraints()
@@ -356,26 +355,27 @@ class TestConverters(QiskitOptimizationTestCase):
         # IntegerToBinaryConverter
         with self.assertRaises(QiskitOptimizationError):
             op = OptimizationProblem()
-            op.variables.add(names=["x", "y"])
-            l_expr = SparsePair(ind=["x"], val=[1.0])
-            q_expr = [["x"], ["y"], [1]]
+            op.variables.add(names=['x', 'y'])
+            l_expr = SparsePair(ind=['x'], val=[1.0])
+            q_expr = [['x'], ['y'], [1]]
             op.quadratic_constraints.add(name=str(1), lin_expr=l_expr, quad_expr=q_expr)
             conv = IntegerToBinaryConverter()
             _ = conv.encode(op)
         # InequalityToEqualityConverter
         with self.assertRaises(QiskitOptimizationError):
             op = OptimizationProblem()
-            op.variables.add(names=["x", "y"])
-            l_expr = SparsePair(ind=["x"], val=[1.0])
-            q_expr = [["x"], ["y"], [1]]
+            op.variables.add(names=['x', 'y'])
+            l_expr = SparsePair(ind=['x'], val=[1.0])
+            q_expr = [['x'], ['y'], [1]]
             op.quadratic_constraints.add(name=str(1), lin_expr=l_expr, quad_expr=q_expr)
             conv = InequalityToEqualityConverter()
             _ = conv.encode(op)
 
     def test_continuous_variable_decode(self):
-        mdl = Model("test_continuous_varable_decode")
-        c = mdl.continuous_var(lb=0, ub=10.9, name="c")
-        x = mdl.binary_var(name="x")
+        """ Test decode func of IntegerToBinaryConverter for continuous variables"""
+        mdl = Model('test_continuous_varable_decode')
+        c = mdl.continuous_var(lb=0, ub=10.9, name='c')
+        x = mdl.binary_var(name='x')
         mdl.maximize(c + x * x)
         op = OptimizationProblem()
         op.from_docplex(mdl)
@@ -394,5 +394,5 @@ class TestConverters(QiskitOptimizationTestCase):
         self.assertEqual(solution.x[0], 10.9)
 
 
-if __name__ == "__main__":
+if __name__ == '__main__':
     unittest.main()

--- a/test/optimization/test_converters.py
+++ b/test/optimization/test_converters.py
@@ -18,11 +18,19 @@ import unittest
 from test.optimization.optimization_test_case import QiskitOptimizationTestCase
 import logging
 
+from qiskit.aqua.operators import WeightedPauliOperator
+from qiskit.aqua.algorithms import NumPyMinimumEigensolver
+from docplex.mp.model import Model
 from qiskit.optimization import OptimizationProblem, QiskitOptimizationError
 from qiskit.optimization.results import OptimizationResult
-from qiskit.optimization.converters import InequalityToEqualityConverter, \
-    OptimizationProblemToOperator, IntegerToBinaryConverter, PenalizeLinearEqualityConstraints
-from qiskit.aqua.operators import WeightedPauliOperator
+from qiskit.optimization.converters import (
+    InequalityToEqualityConverter,
+    OptimizationProblemToOperator,
+    IntegerToBinaryConverter,
+    PenalizeLinearEqualityConstraints,
+)
+from qiskit.optimization.algorithms import MinimumEigenOptimizer, CplexOptimizer, ADMMOptimizer
+from qiskit.optimization.algorithms.admm_optimizer import ADMMParameters
 from qiskit.quantum_info import Pauli
 
 logger = logging.getLogger(__name__)
@@ -30,31 +38,25 @@ logger = logging.getLogger(__name__)
 _HAS_CPLEX = False
 try:
     from cplex import SparsePair
+
     _HAS_CPLEX = True
 except ImportError:
-    logger.info('CPLEX is not installed.')
+    logger.info("CPLEX is not installed.")
 
 QUBIT_OP_MAXIMIZE_SAMPLE = WeightedPauliOperator(
-    paulis=[[(-199999.5+0j), Pauli(z=[True, False, False, False],
-                                   x=[False, False, False, False])],
-            [(-399999.5+0j), Pauli(z=[False, True, False, False],
-                                   x=[False, False, False, False])],
-            [(-599999.5+0j), Pauli(z=[False, False, True, False],
-                                   x=[False, False, False, False])],
-            [(-799999.5+0j), Pauli(z=[False, False, False, True],
-                                   x=[False, False, False, False])],
-            [(100000+0j), Pauli(z=[True, True, False, False],
-                                x=[False, False, False, False])],
-            [(150000+0j), Pauli(z=[True, False, True, False],
-                                x=[False, False, False, False])],
-            [(200000+0j), Pauli(z=[True, False, False, True],
-                                x=[False, False, False, False])],
-            [(300000+0j), Pauli(z=[False, True, True, False],
-                                x=[False, False, False, False])],
-            [(400000+0j), Pauli(z=[False, True, False, True],
-                                x=[False, False, False, False])],
-            [(600000+0j), Pauli(z=[False, False, True, True],
-                                x=[False, False, False, False])]])
+    paulis=[
+        [(-199999.5 + 0j), Pauli(z=[True, False, False, False], x=[False, False, False, False])],
+        [(-399999.5 + 0j), Pauli(z=[False, True, False, False], x=[False, False, False, False])],
+        [(-599999.5 + 0j), Pauli(z=[False, False, True, False], x=[False, False, False, False])],
+        [(-799999.5 + 0j), Pauli(z=[False, False, False, True], x=[False, False, False, False])],
+        [(100000 + 0j), Pauli(z=[True, True, False, False], x=[False, False, False, False])],
+        [(150000 + 0j), Pauli(z=[True, False, True, False], x=[False, False, False, False])],
+        [(200000 + 0j), Pauli(z=[True, False, False, True], x=[False, False, False, False])],
+        [(300000 + 0j), Pauli(z=[False, True, True, False], x=[False, False, False, False])],
+        [(400000 + 0j), Pauli(z=[False, True, False, True], x=[False, False, False, False])],
+        [(600000 + 0j), Pauli(z=[False, False, True, True], x=[False, False, False, False])],
+    ]
+)
 OFFSET_MAXIMIZE_SAMPLE = 1149998
 
 
@@ -64,7 +66,7 @@ class TestConverters(QiskitOptimizationTestCase):
     def setUp(self) -> None:
         super().setUp()
         if not _HAS_CPLEX:
-            self.skipTest('CPLEX is not installed.')
+            self.skipTest("CPLEX is not installed.")
 
     def test_empty_problem(self):
         """ Test empty problem """
@@ -84,60 +86,62 @@ class TestConverters(QiskitOptimizationTestCase):
         # Integer variable
         with self.assertRaises(QiskitOptimizationError):
             op = OptimizationProblem()
-            op.variables.add(names=['x'], types='I')
+            op.variables.add(names=["x"], types="I")
             conv = OptimizationProblemToOperator()
             _ = conv.encode(op)
         # Continuous variable
         with self.assertRaises(QiskitOptimizationError):
             op = OptimizationProblem()
-            op.variables.add(names=['x'], types='C')
+            op.variables.add(names=["x"], types="C")
             conv = OptimizationProblemToOperator()
             _ = conv.encode(op)
         # Semi-Continuous variable
         with self.assertRaises(QiskitOptimizationError):
             op = OptimizationProblem()
-            op.variables.add(names=['x'], types='S')
+            op.variables.add(names=["x"], types="S")
             conv = OptimizationProblemToOperator()
             _ = conv.encode(op)
         # Semi-Integer variable
         with self.assertRaises(QiskitOptimizationError):
             op = OptimizationProblem()
-            op.variables.add(names=['x'], types='N')
+            op.variables.add(names=["x"], types="N")
             conv = OptimizationProblemToOperator()
             _ = conv.encode(op)
         # validate the types of the variables for InequalityToEqualityConverter
         # Semi-Continuous variable
         with self.assertRaises(QiskitOptimizationError):
             op = OptimizationProblem()
-            op.variables.add(names=['x'], types='S')
+            op.variables.add(names=["x"], types="S")
             conv = InequalityToEqualityConverter()
             _ = conv.encode(op)
         # Semi-Integer variable
         with self.assertRaises(QiskitOptimizationError):
             op = OptimizationProblem()
-            op.variables.add(names=['x'], types='N')
+            op.variables.add(names=["x"], types="N")
             conv = InequalityToEqualityConverter()
             _ = conv.encode(op)
 
     def test_inequality_binary(self):
         """ Test InequalityToEqualityConverter with binary variables """
         op = OptimizationProblem()
-        op.variables.add(names=['x', 'y', 'z'], types='B' * 3)
+        op.variables.add(names=["x", "y", "z"], types="B" * 3)
         op.linear_constraints.add(
-            lin_expr=[SparsePair(ind=['x', 'y'], val=[1, 1]),
-                      SparsePair(ind=['y', 'z'], val=[1, -1]),
-                      SparsePair(ind=['z', 'x'], val=[1, 2])],
-            senses=['E', 'L', 'G'],
+            lin_expr=[
+                SparsePair(ind=["x", "y"], val=[1, 1]),
+                SparsePair(ind=["y", "z"], val=[1, -1]),
+                SparsePair(ind=["z", "x"], val=[1, 2]),
+            ],
+            senses=["E", "L", "G"],
             rhs=[1, 2, 3],
-            names=['xy', 'yz', 'zx']
+            names=["xy", "yz", "zx"],
         )
         conv = InequalityToEqualityConverter()
         op2 = conv.encode(op)
         self.assertEqual(op.get_problem_name(), op2.get_problem_name())
         self.assertEqual(op.get_problem_type(), op2.get_problem_type())
         cst = op2.linear_constraints
-        self.assertListEqual(cst.get_names(), ['xy', 'yz', 'zx'])
-        self.assertListEqual(cst.get_senses(), ['E', 'E', 'E'])
+        self.assertListEqual(cst.get_names(), ["xy", "yz", "zx"])
+        self.assertListEqual(cst.get_senses(), ["E", "E", "E"])
         self.assertListEqual(cst.get_rhs(), [1, 2, 3])
         var = op2.variables
         self.assertListEqual(var.get_lower_bounds(3, 4), [0, 0])
@@ -146,23 +150,24 @@ class TestConverters(QiskitOptimizationTestCase):
     def test_inequality_integer(self):
         """ Test InequalityToEqualityConverter with integer variables """
         op = OptimizationProblem()
-        op.variables.add(names=['x', 'y', 'z'],
-                         types='I' * 3, lb=[-3] * 3, ub=[3] * 3)
+        op.variables.add(names=["x", "y", "z"], types="I" * 3, lb=[-3] * 3, ub=[3] * 3)
         op.linear_constraints.add(
-            lin_expr=[SparsePair(ind=['x', 'y'], val=[1, 1]),
-                      SparsePair(ind=['y', 'z'], val=[1, -1]),
-                      SparsePair(ind=['z', 'x'], val=[1, 2])],
-            senses=['E', 'L', 'G'],
+            lin_expr=[
+                SparsePair(ind=["x", "y"], val=[1, 1]),
+                SparsePair(ind=["y", "z"], val=[1, -1]),
+                SparsePair(ind=["z", "x"], val=[1, 2]),
+            ],
+            senses=["E", "L", "G"],
             rhs=[1, 2, 3],
-            names=['xy', 'yz', 'zx']
+            names=["xy", "yz", "zx"],
         )
         conv = InequalityToEqualityConverter()
         op2 = conv.encode(op)
         self.assertEqual(op.get_problem_name(), op2.get_problem_name())
         self.assertEqual(op.get_problem_type(), op2.get_problem_type())
         cst = op2.linear_constraints
-        self.assertListEqual(cst.get_names(), ['xy', 'yz', 'zx'])
-        self.assertListEqual(cst.get_senses(), ['E', 'E', 'E'])
+        self.assertListEqual(cst.get_names(), ["xy", "yz", "zx"])
+        self.assertListEqual(cst.get_senses(), ["E", "E", "E"])
         self.assertListEqual(cst.get_rhs(), [1, 2, 3])
         var = op2.variables
         self.assertListEqual(var.get_lower_bounds(3, 4), [0, 0])
@@ -171,65 +176,73 @@ class TestConverters(QiskitOptimizationTestCase):
     def test_inequality_mode_integer(self):
         """ Test integer mode of InequalityToEqualityConverter() """
         op = OptimizationProblem()
-        op.variables.add(names=['x', 'y', 'z'], types='B' * 3)
+        op.variables.add(names=["x", "y", "z"], types="B" * 3)
         op.linear_constraints.add(
-            lin_expr=[SparsePair(ind=['x', 'y'], val=[1, 1]),
-                      SparsePair(ind=['y', 'z'], val=[1, -1]),
-                      SparsePair(ind=['z', 'x'], val=[1, 2])],
-            senses=['E', 'L', 'G'],
+            lin_expr=[
+                SparsePair(ind=["x", "y"], val=[1, 1]),
+                SparsePair(ind=["y", "z"], val=[1, -1]),
+                SparsePair(ind=["z", "x"], val=[1, 2]),
+            ],
+            senses=["E", "L", "G"],
             rhs=[1, 2, 3],
-            names=['xy', 'yz', 'zx']
+            names=["xy", "yz", "zx"],
         )
         conv = InequalityToEqualityConverter()
-        op2 = conv.encode(op, mode='integer')
+        op2 = conv.encode(op, mode="integer")
         var = op2.variables
-        self.assertListEqual(var.get_types(3, 4), ['I', 'I'])
+        self.assertListEqual(var.get_types(3, 4), ["I", "I"])
 
     def test_inequality_mode_continuous(self):
         """ Test continuous mode of InequalityToEqualityConverter() """
         op = OptimizationProblem()
-        op.variables.add(names=['x', 'y', 'z'], types='B' * 3)
+        op.variables.add(names=["x", "y", "z"], types="B" * 3)
         op.linear_constraints.add(
-            lin_expr=[SparsePair(ind=['x', 'y'], val=[1, 1]),
-                      SparsePair(ind=['y', 'z'], val=[1, -1]),
-                      SparsePair(ind=['z', 'x'], val=[1, 2])],
-            senses=['E', 'L', 'G'],
+            lin_expr=[
+                SparsePair(ind=["x", "y"], val=[1, 1]),
+                SparsePair(ind=["y", "z"], val=[1, -1]),
+                SparsePair(ind=["z", "x"], val=[1, 2]),
+            ],
+            senses=["E", "L", "G"],
             rhs=[1, 2, 3],
-            names=['xy', 'yz', 'zx']
+            names=["xy", "yz", "zx"],
         )
         conv = InequalityToEqualityConverter()
-        op2 = conv.encode(op, mode='continuous')
+        op2 = conv.encode(op, mode="continuous")
         var = op2.variables
-        self.assertListEqual(var.get_types(3, 4), ['C', 'C'])
+        self.assertListEqual(var.get_types(3, 4), ["C", "C"])
 
     def test_inequality_mode_auto(self):
         """ Test auto mode of InequalityToEqualityConverter() """
         op = OptimizationProblem()
-        op.variables.add(names=['x', 'y', 'z'], types='B' * 3)
+        op.variables.add(names=["x", "y", "z"], types="B" * 3)
         op.linear_constraints.add(
-            lin_expr=[SparsePair(ind=['x', 'y'], val=[1, 1]),
-                      SparsePair(ind=['y', 'z'], val=[1, -1]),
-                      SparsePair(ind=['z', 'x'], val=[1.1, 2.2])],
-            senses=['E', 'L', 'G'],
+            lin_expr=[
+                SparsePair(ind=["x", "y"], val=[1, 1]),
+                SparsePair(ind=["y", "z"], val=[1, -1]),
+                SparsePair(ind=["z", "x"], val=[1.1, 2.2]),
+            ],
+            senses=["E", "L", "G"],
             rhs=[1, 2, 3.3],
-            names=['xy', 'yz', 'zx']
+            names=["xy", "yz", "zx"],
         )
         conv = InequalityToEqualityConverter()
-        op2 = conv.encode(op, mode='auto')
+        op2 = conv.encode(op, mode="auto")
         var = op2.variables
-        self.assertListEqual(var.get_types(3, 4), ['I', 'C'])
+        self.assertListEqual(var.get_types(3, 4), ["I", "C"])
 
     def test_penalize_sense(self):
         """ Test PenalizeLinearEqualityConstraints with senses """
         op = OptimizationProblem()
-        op.variables.add(names=['x', 'y', 'z'], types='B' * 3)
+        op.variables.add(names=["x", "y", "z"], types="B" * 3)
         op.linear_constraints.add(
-            lin_expr=[SparsePair(ind=['x', 'y'], val=[1, 1]),
-                      SparsePair(ind=['y', 'z'], val=[1, -1]),
-                      SparsePair(ind=['z', 'x'], val=[1, 2])],
-            senses=['E', 'L', 'G'],
+            lin_expr=[
+                SparsePair(ind=["x", "y"], val=[1, 1]),
+                SparsePair(ind=["y", "z"], val=[1, -1]),
+                SparsePair(ind=["z", "x"], val=[1, 2]),
+            ],
+            senses=["E", "L", "G"],
             rhs=[1, 2, 3],
-            names=['xy', 'yz', 'zx']
+            names=["xy", "yz", "zx"],
         )
         self.assertEqual(op.linear_constraints.get_num(), 3)
         conv = PenalizeLinearEqualityConstraints()
@@ -239,13 +252,15 @@ class TestConverters(QiskitOptimizationTestCase):
     def test_penalize_binary(self):
         """ Test PenalizeLinearEqualityConstraints with binary variables """
         op = OptimizationProblem()
-        op.variables.add(names=['x', 'y', 'z'], types='B' * 3)
+        op.variables.add(names=["x", "y", "z"], types="B" * 3)
         op.linear_constraints.add(
-            lin_expr=[SparsePair(ind=['x', 'y'], val=[1, 1]),
-                      SparsePair(ind=['y', 'z'], val=[1, -1])],
-            senses=['E', 'E'],
+            lin_expr=[
+                SparsePair(ind=["x", "y"], val=[1, 1]),
+                SparsePair(ind=["y", "z"], val=[1, -1]),
+            ],
+            senses=["E", "E"],
             rhs=[1, 2],
-            names=['xy', 'yz']
+            names=["xy", "yz"],
         )
         self.assertEqual(op.linear_constraints.get_num(), 2)
         conv = PenalizeLinearEqualityConstraints()
@@ -255,14 +270,15 @@ class TestConverters(QiskitOptimizationTestCase):
     def test_penalize_integer(self):
         """ Test PenalizeLinearEqualityConstraints with integer variables """
         op = OptimizationProblem()
-        op.variables.add(names=['x', 'y', 'z'],
-                         types='I' * 3, lb=[-3] * 3, ub=[3] * 3)
+        op.variables.add(names=["x", "y", "z"], types="I" * 3, lb=[-3] * 3, ub=[3] * 3)
         op.linear_constraints.add(
-            lin_expr=[SparsePair(ind=['x', 'y'], val=[1, 1]),
-                      SparsePair(ind=['y', 'z'], val=[1, -1])],
-            senses=['E', 'E'],
+            lin_expr=[
+                SparsePair(ind=["x", "y"], val=[1, 1]),
+                SparsePair(ind=["y", "z"], val=[1, -1]),
+            ],
+            senses=["E", "E"],
             rhs=[1, 2],
-            names=['xy', 'yz']
+            names=["xy", "yz"],
         )
         self.assertEqual(op.linear_constraints.get_num(), 2)
         conv = PenalizeLinearEqualityConstraints()
@@ -272,47 +288,46 @@ class TestConverters(QiskitOptimizationTestCase):
     def test_integer_to_binary(self):
         """ Test integer to binary """
         op = OptimizationProblem()
-        op.variables.add(names=['x', 'y', 'z'], types='BIC',
-                         lb=[0, 0, 0], ub=[1, 6, 10])
-        op.objective.set_linear([('x', 1), ('y', 2), ('z', 1)])
+        op.variables.add(names=["x", "y", "z"], types="BIC", lb=[0, 0, 0], ub=[1, 6, 10])
+        op.objective.set_linear([("x", 1), ("y", 2), ("z", 1)])
         op.linear_constraints.add(
-            lin_expr=[SparsePair(ind=['x', 'y', 'z'], val=[1, 3, 1])],
-            senses=['L'],
+            lin_expr=[SparsePair(ind=["x", "y", "z"], val=[1, 3, 1])],
+            senses=["L"],
             rhs=[10],
-            names=['xyz']
+            names=["xyz"],
         )
         self.assertEqual(op.variables.get_num(), 3)
         conv = IntegerToBinaryConverter()
         op2 = conv.encode(op)
         names = op2.variables.get_names()
-        self.assertIn('x', names)
-        self.assertIn('z', names)
+        self.assertIn("x", names)
+        self.assertIn("z", names)
         variables = op2.variables
-        self.assertEqual(variables.get_lower_bounds('x'), 0.0)
-        self.assertEqual(variables.get_lower_bounds('z'), 0.0)
-        self.assertEqual(variables.get_upper_bounds('x'), 1.0)
-        self.assertEqual(variables.get_upper_bounds('z'), 10.0)
-        self.assertListEqual(variables.get_types(['x', 'y@0', 'y@1', 'y@2', 'z']),
-                             ['B', 'B', 'B', 'B', 'C'])
-        self.assertListEqual(op2.objective.get_linear(['y@0', 'y@1', 'y@2']), [2, 4, 6])
+        self.assertEqual(variables.get_lower_bounds("x"), 0.0)
+        self.assertEqual(variables.get_lower_bounds("z"), 0.0)
+        self.assertEqual(variables.get_upper_bounds("x"), 1.0)
+        self.assertEqual(variables.get_upper_bounds("z"), 10.0)
+        self.assertListEqual(
+            variables.get_types(["x", "y@0", "y@1", "y@2", "z"]), ["B", "B", "B", "B", "C"]
+        )
+        self.assertListEqual(op2.objective.get_linear(["y@0", "y@1", "y@2"]), [2, 4, 6])
         self.assertListEqual(op2.linear_constraints.get_rows()[0].val, [1, 3, 6, 9, 1])
 
     def test_binary_to_integer(self):
         """ Test binary to integer """
         op = OptimizationProblem()
-        op.variables.add(names=['x', 'y', 'z'], types='BIB', lb=[
-            0, 0, 0], ub=[1, 7, 1])
-        op.objective.set_linear([('x', 2), ('y', 1), ('z', 1)])
+        op.variables.add(names=["x", "y", "z"], types="BIB", lb=[0, 0, 0], ub=[1, 7, 1])
+        op.objective.set_linear([("x", 2), ("y", 1), ("z", 1)])
         op.linear_constraints.add(
-            lin_expr=[SparsePair(ind=['x', 'y', 'z'], val=[1, 1, 1])],
-            senses=['L'],
+            lin_expr=[SparsePair(ind=["x", "y", "z"], val=[1, 1, 1])],
+            senses=["L"],
             rhs=[7],
-            names=['xyz']
+            names=["xyz"],
         )
         op.objective.set_sense(-1)
         conv = IntegerToBinaryConverter()
         _ = conv.encode(op)
-        result = OptimizationResult(x=[1, 0., 1, 1, 0], fval=8)
+        result = OptimizationResult(x=[1, 0.0, 1, 1, 0], fval=8)
         new_result = conv.decode(result)
         self.assertListEqual(new_result.x, [1, 6, 0])
         self.assertEqual(new_result.fval, 8)
@@ -320,13 +335,13 @@ class TestConverters(QiskitOptimizationTestCase):
     def test_optimizationproblem_to_operator(self):
         """ Test optimization problem to operators"""
         op = OptimizationProblem()
-        op.variables.add(names=['a', 'b', 'c', 'd'], types='B'*4)
-        op.objective.set_linear([('a', 1), ('b', 1), ('c', 1), ('d', 1)])
+        op.variables.add(names=["a", "b", "c", "d"], types="B" * 4)
+        op.objective.set_linear([("a", 1), ("b", 1), ("c", 1), ("d", 1)])
         op.linear_constraints.add(
-            lin_expr=[SparsePair(ind=['a', 'b', 'c', 'd'], val=[1, 2, 3, 4])],
-            senses=['E'],
+            lin_expr=[SparsePair(ind=["a", "b", "c", "d"], val=[1, 2, 3, 4])],
+            senses=["E"],
             rhs=[3],
-            names=['abcd']
+            names=["abcd"],
         )
         op.objective.set_sense(-1)
         penalize = PenalizeLinearEqualityConstraints()
@@ -341,22 +356,43 @@ class TestConverters(QiskitOptimizationTestCase):
         # IntegerToBinaryConverter
         with self.assertRaises(QiskitOptimizationError):
             op = OptimizationProblem()
-            op.variables.add(names=['x', 'y'])
-            l_expr = SparsePair(ind=['x'], val=[1.0])
-            q_expr = [['x'], ['y'], [1]]
+            op.variables.add(names=["x", "y"])
+            l_expr = SparsePair(ind=["x"], val=[1.0])
+            q_expr = [["x"], ["y"], [1]]
             op.quadratic_constraints.add(name=str(1), lin_expr=l_expr, quad_expr=q_expr)
             conv = IntegerToBinaryConverter()
             _ = conv.encode(op)
         # InequalityToEqualityConverter
         with self.assertRaises(QiskitOptimizationError):
             op = OptimizationProblem()
-            op.variables.add(names=['x', 'y'])
-            l_expr = SparsePair(ind=['x'], val=[1.0])
-            q_expr = [['x'], ['y'], [1]]
+            op.variables.add(names=["x", "y"])
+            l_expr = SparsePair(ind=["x"], val=[1.0])
+            q_expr = [["x"], ["y"], [1]]
             op.quadratic_constraints.add(name=str(1), lin_expr=l_expr, quad_expr=q_expr)
             conv = InequalityToEqualityConverter()
             _ = conv.encode(op)
 
+    def test_continuous_variable_decode(self):
+        mdl = Model("test_continuous_varable_decode")
+        c = mdl.continuous_var(lb=0, ub=10.9, name="c")
+        x = mdl.binary_var(name="x")
+        mdl.maximize(c + x * x)
+        op = OptimizationProblem()
+        op.from_docplex(mdl)
+        converter = IntegerToBinaryConverter()
+        op = converter.encode(op)
+        admm_params = ADMMParameters()
+        qubo_optimizer = MinimumEigenOptimizer(NumPyMinimumEigensolver())
+        continuous_optimizer = CplexOptimizer()
+        solver = ADMMOptimizer(
+            qubo_optimizer=qubo_optimizer,
+            continuous_optimizer=continuous_optimizer,
+            params=admm_params,
+        )
+        solution = solver.solve(op)
+        solution = converter.decode(solution)
+        self.assertEqual(solution.x[0], 10.9)
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
### Summary  
Fixed a bug of `decode` func of `IntegerToBinaryConverter` for continuous variables.

### Details and comments
Solutions of continuous variables are rounded (converted in int values) for all variables. This PR fixed it.


