### PR TITLE
``is_compatible`` to return a bool

### DIFF
--- a/.pylintdict
+++ b/.pylintdict
@@ -401,7 +401,7 @@ online
 onwards
 oplus
 optim
-OptimizationProblem
+QuadraticProgram
 optimizer's
 optimizers
 orbsym

--- a/qiskit/optimization/__init__.py
+++ b/qiskit/optimization/__init__.py
@@ -29,12 +29,12 @@ Submodules
 
 from .infinity import infinity  # must be at the top of the file
 from .utils import QiskitOptimizationError
-from .problems import OptimizationProblem
+from .problems import QuadraticProgram
 from ._logging import (get_qiskit_optimization_logging,
                        set_qiskit_optimization_logging)
 from .util import get_qubo_solutions
 
-__all__ = ['OptimizationProblem',
+__all__ = ['QuadraticProgram',
            'QiskitOptimizationError',
            'get_qiskit_optimization_logging',
            'set_qiskit_optimization_logging',

--- a/qiskit/optimization/algorithms/admm_optimizer.py
+++ b/qiskit/optimization/algorithms/admm_optimizer.py
@@ -23,7 +23,6 @@ from qiskit.optimization.algorithms.optimization_algorithm import OptimizationAl
 from qiskit.optimization.problems.quadratic_program import QuadraticProgram
 from qiskit.optimization.problems.variables import CPX_BINARY, CPX_CONTINUOUS
 from qiskit.optimization.results.optimization_result import OptimizationResult
-from qiskit.optimization.utils.qiskit_optimization_error import QiskitOptimizationError
 
 UPDATE_RHO_BY_TEN_PERCENT = 0
 UPDATE_RHO_BY_RESIDUALS = 1
@@ -211,7 +210,7 @@ class ADMMOptimizer(OptimizationAlgorithm):
         # the solve method.
         self._state: Optional[ADMMState] = None
 
-    def is_compatible(self, problem: QuadraticProgram) -> Optional[str]:
+    def get_incompatibility(self, problem: QuadraticProgram) -> Optional[str]:
         """Checks whether a given problem can be solved with the optimizer implementing this method.
 
         Args:
@@ -250,10 +249,7 @@ class ADMMOptimizer(OptimizationAlgorithm):
             msg += 'Quadratic constraints are not supported. '
 
         # if an error occurred, return error message, otherwise, return None
-        if len(msg) > 0:
-            raise QiskitOptimizationError('The problem is not compatible with ADMM: %s' % msg)
-
-        return None
+        return msg
 
     def solve(self, problem: QuadraticProgram) -> ADMMOptimizerResult:
         """Tries to solves the given problem using ADMM algorithm.

--- a/qiskit/optimization/algorithms/admm_optimizer.py
+++ b/qiskit/optimization/algorithms/admm_optimizer.py
@@ -23,6 +23,7 @@ from qiskit.optimization.algorithms.optimization_algorithm import OptimizationAl
 from qiskit.optimization.problems.optimization_problem import OptimizationProblem
 from qiskit.optimization.problems.variables import CPX_BINARY, CPX_CONTINUOUS
 from qiskit.optimization.results.optimization_result import OptimizationResult
+from qiskit.optimization.utils.qiskit_optimization_error import QiskitOptimizationError
 
 UPDATE_RHO_BY_TEN_PERCENT = 0
 UPDATE_RHO_BY_RESIDUALS = 1
@@ -210,21 +211,26 @@ class ADMMOptimizer(OptimizationAlgorithm):
         # the solve method.
         self._state: Optional[ADMMState] = None
 
-    def is_compatible(self, problem: OptimizationProblem) -> Optional[str]:
+    def is_compatible(self, problem: OptimizationProblem) -> bool:
         """Checks whether a given problem can be solved with the optimizer implementing this method.
 
         Args:
             problem: The optimization problem to check compatibility.
 
         Returns:
-            Returns ``None`` if the problem is compatible and else a string with the error message.
+            Returns True if the problem is compatible, otherwise raises an error.
+
+        Raises:
+            QiskitOptimizationError: If the problem is not compatible with the ADMM optimizer.
         """
+
+        msg = ''
 
         # 1. only binary and continuous variables are supported
         for var_type in problem.variables.get_types():
             if var_type not in (CPX_BINARY, CPX_CONTINUOUS):
                 # variable is not binary and not continuous.
-                return "Only binary and continuous variables are supported"
+                msg += 'Only binary and continuous variables are supported. '
 
         binary_indices = self._get_variable_indices(problem, CPX_BINARY)
         continuous_indices = self._get_variable_indices(problem, CPX_CONTINUOUS)
@@ -235,15 +241,19 @@ class ADMMOptimizer(OptimizationAlgorithm):
                 coeff = problem.objective.get_quadratic_coefficients(binary_index, continuous_index)
                 if coeff != 0:
                     # binary and continuous vars are mixed.
-                    return "Binary and continuous variables are not separable in the objective"
+                    msg += 'Binary and continuous variables are not separable in the objective. '
 
         # 3. no quadratic constraints are supported.
         quad_constraints = problem.quadratic_constraints.get_num()
         if quad_constraints is not None and quad_constraints > 0:
             # quadratic constraints are not supported.
-            return "Quadratic constraints are not supported"
+            msg += 'Quadratic constraints are not supported. '
 
-        return None
+        # if an error occurred, return error message, otherwise, return None
+        if len(msg) > 0:
+            raise QiskitOptimizationError('The problem is not compatible with ADMM: %s' % msg)
+
+        return True
 
     def solve(self, problem: OptimizationProblem) -> ADMMOptimizerResult:
         """Tries to solves the given problem using ADMM algorithm.
@@ -619,7 +629,7 @@ class ADMMOptimizer(OptimizationAlgorithm):
             2 * (
                 self._params.factor_c / 2 * np.dot(self._state.a0.transpose(), self._state.a0) +
                 self._state.rho / 2 * np.eye(binary_size)
-                )
+            )
         for i in range(binary_size):
             for j in range(i, binary_size):
                 op1.objective.set_quadratic_coefficients(i, j, quadratic_objective[i, j])

--- a/qiskit/optimization/algorithms/admm_optimizer.py
+++ b/qiskit/optimization/algorithms/admm_optimizer.py
@@ -20,7 +20,7 @@ import numpy as np
 
 from qiskit.optimization.algorithms.cplex_optimizer import CplexOptimizer
 from qiskit.optimization.algorithms.optimization_algorithm import OptimizationAlgorithm
-from qiskit.optimization.problems.optimization_problem import OptimizationProblem
+from qiskit.optimization.problems.quadratic_program import QuadraticProgram
 from qiskit.optimization.problems.variables import CPX_BINARY, CPX_CONTINUOUS
 from qiskit.optimization.results.optimization_result import OptimizationResult
 from qiskit.optimization.utils.qiskit_optimization_error import QiskitOptimizationError
@@ -93,7 +93,7 @@ class ADMMState:
     """
 
     def __init__(self,
-                 op: OptimizationProblem,
+                 op: QuadraticProgram,
                  binary_indices: List[int],
                  continuous_indices: List[int],
                  rho_initial: float) -> None:
@@ -211,7 +211,7 @@ class ADMMOptimizer(OptimizationAlgorithm):
         # the solve method.
         self._state: Optional[ADMMState] = None
 
-    def is_compatible(self, problem: OptimizationProblem) -> bool:
+    def is_compatible(self, problem: QuadraticProgram) -> Optional[str]:
         """Checks whether a given problem can be solved with the optimizer implementing this method.
 
         Args:
@@ -253,9 +253,9 @@ class ADMMOptimizer(OptimizationAlgorithm):
         if len(msg) > 0:
             raise QiskitOptimizationError('The problem is not compatible with ADMM: %s' % msg)
 
-        return True
+        return None
 
-    def solve(self, problem: OptimizationProblem) -> ADMMOptimizerResult:
+    def solve(self, problem: QuadraticProgram) -> ADMMOptimizerResult:
         """Tries to solves the given problem using ADMM algorithm.
 
         Args:
@@ -347,7 +347,7 @@ class ADMMOptimizer(OptimizationAlgorithm):
         return result
 
     @staticmethod
-    def _get_variable_indices(op: OptimizationProblem, var_type: str) -> List[int]:
+    def _get_variable_indices(op: QuadraticProgram, var_type: str) -> List[int]:
         """Returns a list of indices of the variables of the specified type.
 
         Args:
@@ -607,13 +607,13 @@ class ADMMOptimizer(OptimizationAlgorithm):
         a_3 = matrix[:, len(self._state.binary_indices):]
         return a_2, a_3, b_2
 
-    def _create_step1_problem(self) -> OptimizationProblem:
+    def _create_step1_problem(self) -> QuadraticProgram:
         """Creates a step 1 sub-problem.
 
         Returns:
             A newly created optimization problem.
         """
-        op1 = OptimizationProblem()
+        op1 = QuadraticProgram()
 
         binary_size = len(self._state.binary_indices)
         # create the same binary variables.
@@ -644,13 +644,13 @@ class ADMMOptimizer(OptimizationAlgorithm):
             op1.objective.set_linear(i, linear_objective[i])
         return op1
 
-    def _create_step2_problem(self) -> OptimizationProblem:
+    def _create_step2_problem(self) -> QuadraticProgram:
         """Creates a step 2 sub-problem.
 
         Returns:
             A newly created optimization problem.
         """
-        op2 = OptimizationProblem()
+        op2 = QuadraticProgram()
 
         continuous_size = len(self._state.continuous_indices)
         binary_size = len(self._state.binary_indices)
@@ -730,13 +730,13 @@ class ADMMOptimizer(OptimizationAlgorithm):
 
         return op2
 
-    def _create_step3_problem(self) -> OptimizationProblem:
+    def _create_step3_problem(self) -> QuadraticProgram:
         """Creates a step 3 sub-problem.
 
         Returns:
             A newly created optimization problem.
         """
-        op3 = OptimizationProblem()
+        op3 = QuadraticProgram()
         # add y variables.
         binary_size = len(self._state.binary_indices)
         op3.variables.add(names=["y_" + str(i + 1) for i in range(binary_size)],
@@ -758,22 +758,22 @@ class ADMMOptimizer(OptimizationAlgorithm):
 
         return op3
 
-    def _update_x0(self, op1: OptimizationProblem) -> np.ndarray:
-        """Solves the Step1 OptimizationProblem via the qubo optimizer.
+    def _update_x0(self, op1: QuadraticProgram) -> np.ndarray:
+        """Solves the Step1 QuadraticProgram via the qubo optimizer.
 
         Args:
-            op1: the Step1 OptimizationProblem.
+            op1: the Step1 QuadraticProgram.
 
         Returns:
             A solution of the Step1, as a numpy array.
         """
         return np.asarray(self._qubo_optimizer.solve(op1).x)
 
-    def _update_x1(self, op2: OptimizationProblem) -> (np.ndarray, np.ndarray):
-        """Solves the Step2 OptimizationProblem via the continuous optimizer.
+    def _update_x1(self, op2: QuadraticProgram) -> (np.ndarray, np.ndarray):
+        """Solves the Step2 QuadraticProgram via the continuous optimizer.
 
         Args:
-            op2: the Step2 OptimizationProblem
+            op2: the Step2 QuadraticProgram
 
         Returns:
             A solution of the Step2, as a pair of numpy arrays.
@@ -786,11 +786,11 @@ class ADMMOptimizer(OptimizationAlgorithm):
         vars_z = np.asarray(vars_op2[len(self._state.continuous_indices):])
         return vars_u, vars_z
 
-    def _update_y(self, op3: OptimizationProblem) -> np.ndarray:
-        """Solves the Step3 OptimizationProblem via the continuous optimizer.
+    def _update_y(self, op3: QuadraticProgram) -> np.ndarray:
+        """Solves the Step3 QuadraticProgram via the continuous optimizer.
 
         Args:
-            op3: the Step3 OptimizationProblem
+            op3: the Step3 QuadraticProgram
 
         Returns:
             A solution of the Step3, as a numpy array.

--- a/qiskit/optimization/algorithms/admm_optimizer.py
+++ b/qiskit/optimization/algorithms/admm_optimizer.py
@@ -210,7 +210,7 @@ class ADMMOptimizer(OptimizationAlgorithm):
         # the solve method.
         self._state: Optional[ADMMState] = None
 
-    def get_incompatibility(self, problem: QuadraticProgram) -> Optional[str]:
+    def get_compatibility_msg(self, problem: QuadraticProgram) -> Optional[str]:
         """Checks whether a given problem can be solved with the optimizer implementing this method.
 
         Args:

--- a/qiskit/optimization/algorithms/cobyla_optimizer.py
+++ b/qiskit/optimization/algorithms/cobyla_optimizer.py
@@ -22,7 +22,7 @@ from scipy.optimize import fmin_cobyla
 
 from qiskit.optimization.algorithms import OptimizationAlgorithm
 from qiskit.optimization.results import OptimizationResult
-from qiskit.optimization.problems import OptimizationProblem
+from qiskit.optimization.problems import QuadraticProgram
 from qiskit.optimization import QiskitOptimizationError
 from qiskit.optimization import infinity
 
@@ -36,7 +36,7 @@ class CobylaOptimizer(OptimizationAlgorithm):
     The arguments for ``fmin_cobyla`` are passed via the constructor.
 
     Examples:
-        >>> problem = OptimizationProblem()
+        >>> problem = QuadraticProgram()
         >>> # specify problem here
         >>> optimizer = CobylaOptimizer()
         >>> result = optimizer.solve(problem)
@@ -67,7 +67,7 @@ class CobylaOptimizer(OptimizationAlgorithm):
         self._disp = disp
         self._catol = catol
 
-    def get_incompatibility(self, problem: OptimizationProblem) -> str:
+    def get_incompatibility(self, problem: QuadraticProgram) -> str:
         """Checks whether a given problem can be solved with this optimizer.
 
         Checks whether the given problem is compatible, i.e., whether the problem contains only
@@ -85,7 +85,7 @@ class CobylaOptimizer(OptimizationAlgorithm):
 
         return ''
 
-    def solve(self, problem: OptimizationProblem) -> OptimizationResult:
+    def solve(self, problem: QuadraticProgram) -> OptimizationResult:
         """Tries to solves the given problem using the optimizer.
 
         Runs the optimizer to try to solve the optimization problem.

--- a/qiskit/optimization/algorithms/cobyla_optimizer.py
+++ b/qiskit/optimization/algorithms/cobyla_optimizer.py
@@ -67,7 +67,7 @@ class CobylaOptimizer(OptimizationAlgorithm):
         self._disp = disp
         self._catol = catol
 
-    def get_incompatibility(self, problem: QuadraticProgram) -> str:
+    def get_compatibility_msg(self, problem: QuadraticProgram) -> str:
         """Checks whether a given problem can be solved with this optimizer.
 
         Checks whether the given problem is compatible, i.e., whether the problem contains only
@@ -100,7 +100,7 @@ class CobylaOptimizer(OptimizationAlgorithm):
             QiskitOptimizationError: If the problem is incompatible with the optimizer.
         """
         # check compatibility and raise exception if incompatible
-        msg = self.get_incompatibility(problem)
+        msg = self.get_compatibility_msg(problem)
         if len(msg) > 0:
             raise QiskitOptimizationError('Incompatible problem: {}'.format(msg))
 

--- a/qiskit/optimization/algorithms/cobyla_optimizer.py
+++ b/qiskit/optimization/algorithms/cobyla_optimizer.py
@@ -67,7 +67,7 @@ class CobylaOptimizer(OptimizationAlgorithm):
         self._disp = disp
         self._catol = catol
 
-    def is_compatible(self, problem: OptimizationProblem) -> Optional[str]:
+    def is_compatible(self, problem: OptimizationProblem) -> bool:
         """Checks whether a given problem can be solved with this optimizer.
 
         Checks whether the given problem is compatible, i.e., whether the problem contains only
@@ -77,21 +77,16 @@ class CobylaOptimizer(OptimizationAlgorithm):
             problem: The optimization problem to check compatibility.
 
         Returns:
-            Returns ``None`` if the problem is compatible and else a string with the error message.
+            Returns True if the problem is compatible, otherwise raises an error.
+
+        Raises:
+            QiskitOptimizationError: If the problem contains non-continuous variables.
         """
-
-        # initialize message
-        msg = ''
-
         # check whether there are variables of type other than continuous
         if problem.variables.get_num() > problem.variables.get_num_continuous():
-            msg += 'This optimizer supports only continuous variables! '
+            raise QiskitOptimizationError('The COBYLA optimizer supports only continuous variables')
 
-        # if an error occurred, return error message, otherwise, return None
-        if len(msg) > 0:
-            return msg.strip()
-        else:
-            return None
+        return True
 
     def solve(self, problem: OptimizationProblem) -> OptimizationResult:
         """Tries to solves the given problem using the optimizer.
@@ -109,9 +104,8 @@ class CobylaOptimizer(OptimizationAlgorithm):
         """
 
         # check compatibility and raise exception if incompatible
-        msg = self.is_compatible(problem)
-        if msg:
-            raise QiskitOptimizationError('Incompatible problem: {}'.format(msg))
+        if not self.is_compatible(problem):
+            raise QiskitOptimizationError('Incompatible problem.')
 
         # get number of variables
         num_vars = problem.variables.get_num()

--- a/qiskit/optimization/algorithms/cobyla_optimizer.py
+++ b/qiskit/optimization/algorithms/cobyla_optimizer.py
@@ -67,7 +67,7 @@ class CobylaOptimizer(OptimizationAlgorithm):
         self._disp = disp
         self._catol = catol
 
-    def is_compatible(self, problem: OptimizationProblem) -> bool:
+    def get_incompatibility(self, problem: OptimizationProblem) -> str:
         """Checks whether a given problem can be solved with this optimizer.
 
         Checks whether the given problem is compatible, i.e., whether the problem contains only
@@ -77,16 +77,13 @@ class CobylaOptimizer(OptimizationAlgorithm):
             problem: The optimization problem to check compatibility.
 
         Returns:
-            Returns True if the problem is compatible, otherwise raises an error.
-
-        Raises:
-            QiskitOptimizationError: If the problem contains non-continuous variables.
+            Returns a string describing the incompatibility.
         """
         # check whether there are variables of type other than continuous
         if problem.variables.get_num() > problem.variables.get_num_continuous():
-            raise QiskitOptimizationError('The COBYLA optimizer supports only continuous variables')
+            return 'The COBYLA optimizer supports only continuous variables'
 
-        return True
+        return ''
 
     def solve(self, problem: OptimizationProblem) -> OptimizationResult:
         """Tries to solves the given problem using the optimizer.
@@ -102,10 +99,10 @@ class CobylaOptimizer(OptimizationAlgorithm):
         Raises:
             QiskitOptimizationError: If the problem is incompatible with the optimizer.
         """
-
         # check compatibility and raise exception if incompatible
-        if not self.is_compatible(problem):
-            raise QiskitOptimizationError('Incompatible problem.')
+        msg = self.get_incompatibility(problem)
+        if len(msg) > 0:
+            raise QiskitOptimizationError('Incompatible problem: {}'.format(msg))
 
         # get number of variables
         num_vars = problem.variables.get_num()

--- a/qiskit/optimization/algorithms/cplex_optimizer.py
+++ b/qiskit/optimization/algorithms/cplex_optimizer.py
@@ -84,7 +84,7 @@ class CplexOptimizer(OptimizationAlgorithm):
         self._parameter_set = parameter_set
 
     # pylint:disable=unused-argument
-    def get_incompatibility(self, problem: QuadraticProgram) -> str:
+    def get_compatibility_msg(self, problem: QuadraticProgram) -> str:
         """Checks whether a given problem can be solved with this optimizer.
 
         Returns ``''`` since CPLEX accepts all problems that can be modeled using the

--- a/qiskit/optimization/algorithms/cplex_optimizer.py
+++ b/qiskit/optimization/algorithms/cplex_optimizer.py
@@ -83,7 +83,7 @@ class CplexOptimizer(OptimizationAlgorithm):
         """
         self._parameter_set = parameter_set
 
-    def is_compatible(self, problem: OptimizationProblem) -> Optional[str]:
+    def is_compatible(self, problem: OptimizationProblem) -> bool:
         """Checks whether a given problem can be solved with this optimizer.
 
         Returns ``True`` since CPLEX accepts all problems that can be modeled using the
@@ -94,9 +94,9 @@ class CplexOptimizer(OptimizationAlgorithm):
             problem: The optimization problem to check compatibility.
 
         Returns:
-            Returns ``None`` if the problem is compatible and else a string with the error message.
+            True.
         """
-        return None
+        return True
 
     def solve(self, problem: OptimizationProblem) -> OptimizationResult:
         """Tries to solves the given problem using the optimizer.

--- a/qiskit/optimization/algorithms/cplex_optimizer.py
+++ b/qiskit/optimization/algorithms/cplex_optimizer.py
@@ -16,7 +16,7 @@
 """The CPLEX optimizer wrapped to be used within Qiskit Optimization.
 
 Examples:
-    >>> problem = OptimizationProblem()
+    >>> problem = QuadraticProgram()
     >>> # specify problem here
     >>> optimizer = CplexOptimizer()
     >>> result = optimizer.solve(problem)
@@ -28,7 +28,7 @@ import logging
 from .optimization_algorithm import OptimizationAlgorithm
 from ..utils.qiskit_optimization_error import QiskitOptimizationError
 from ..results.optimization_result import OptimizationResult
-from ..problems.optimization_problem import OptimizationProblem
+from ..problems.quadratic_program import QuadraticProgram
 
 logger = logging.getLogger(__name__)
 
@@ -83,11 +83,11 @@ class CplexOptimizer(OptimizationAlgorithm):
         """
         self._parameter_set = parameter_set
 
-    def get_incompatibility(self, problem: OptimizationProblem) -> str:
+    def get_incompatibility(self, problem: QuadraticProgram) -> str:
         """Checks whether a given problem can be solved with this optimizer.
 
         Returns ``''`` since CPLEX accepts all problems that can be modeled using the
-        ``OptimizationProblem``. CPLEX may throw an exception in case the problem is determined
+        ``QuadraticProgram``. CPLEX may throw an exception in case the problem is determined
         to be non-convex. This case could be addressed by setting CPLEX parameters accordingly.
 
         Args:
@@ -98,7 +98,7 @@ class CplexOptimizer(OptimizationAlgorithm):
         """
         return ''
 
-    def solve(self, problem: OptimizationProblem) -> OptimizationResult:
+    def solve(self, problem: QuadraticProgram) -> OptimizationResult:
         """Tries to solves the given problem using the optimizer.
 
         Runs the optimizer to try to solve the optimization problem. If problem is not convex,

--- a/qiskit/optimization/algorithms/cplex_optimizer.py
+++ b/qiskit/optimization/algorithms/cplex_optimizer.py
@@ -83,10 +83,10 @@ class CplexOptimizer(OptimizationAlgorithm):
         """
         self._parameter_set = parameter_set
 
-    def is_compatible(self, problem: OptimizationProblem) -> bool:
+    def get_incompatibility(self, problem: OptimizationProblem) -> str:
         """Checks whether a given problem can be solved with this optimizer.
 
-        Returns ``True`` since CPLEX accepts all problems that can be modeled using the
+        Returns ``''`` since CPLEX accepts all problems that can be modeled using the
         ``OptimizationProblem``. CPLEX may throw an exception in case the problem is determined
         to be non-convex. This case could be addressed by setting CPLEX parameters accordingly.
 
@@ -94,9 +94,9 @@ class CplexOptimizer(OptimizationAlgorithm):
             problem: The optimization problem to check compatibility.
 
         Returns:
-            True.
+            An empty string.
         """
-        return True
+        return ''
 
     def solve(self, problem: OptimizationProblem) -> OptimizationResult:
         """Tries to solves the given problem using the optimizer.

--- a/qiskit/optimization/algorithms/cplex_optimizer.py
+++ b/qiskit/optimization/algorithms/cplex_optimizer.py
@@ -83,6 +83,7 @@ class CplexOptimizer(OptimizationAlgorithm):
         """
         self._parameter_set = parameter_set
 
+    # pylint:disable=unused-argument
     def get_incompatibility(self, problem: QuadraticProgram) -> str:
         """Checks whether a given problem can be solved with this optimizer.
 

--- a/qiskit/optimization/algorithms/grover_minimum_finder.py
+++ b/qiskit/optimization/algorithms/grover_minimum_finder.py
@@ -52,7 +52,7 @@ class GroverMinimumFinder(OptimizationAlgorithm):
             quantum_instance = QuantumInstance(backend)
         self._quantum_instance = quantum_instance
 
-    def is_compatible(self, problem: OptimizationProblem) -> Optional[str]:
+    def is_compatible(self, problem: OptimizationProblem) -> bool:
         """Checks whether a given problem can be solved with this optimizer.
 
         Checks whether the given problem is compatible, i.e., whether the problem can be converted
@@ -62,7 +62,7 @@ class GroverMinimumFinder(OptimizationAlgorithm):
             problem: The optimization problem to check compatibility.
 
         Returns:
-            Returns ``None`` if the problem is compatible and else a string with the error message.
+            True, if the problem is compatible and else raise an error.
         """
         return OptimizationProblemToQubo.is_compatible(problem)
 
@@ -81,8 +81,7 @@ class GroverMinimumFinder(OptimizationAlgorithm):
         Raises:
             QiskitOptimizationError: If the problem is incompatible with the optimizer.
         """
-
-        # convert problem to QUBO
+        # convert problem to QUBO, this implicitly checks if the problem is compatible
         qubo_converter = OptimizationProblemToQubo()
         problem_ = qubo_converter.encode(problem)
 

--- a/qiskit/optimization/algorithms/grover_minimum_finder.py
+++ b/qiskit/optimization/algorithms/grover_minimum_finder.py
@@ -52,7 +52,7 @@ class GroverMinimumFinder(OptimizationAlgorithm):
             quantum_instance = QuantumInstance(backend)
         self._quantum_instance = quantum_instance
 
-    def get_incompatibility(self, problem: QuadraticProgram) -> str:
+    def get_compatibility_msg(self, problem: QuadraticProgram) -> str:
         """Checks whether a given problem can be solved with this optimizer.
 
         Checks whether the given problem is compatible, i.e., whether the problem can be converted
@@ -64,7 +64,7 @@ class GroverMinimumFinder(OptimizationAlgorithm):
         Returns:
             A message describing the incompatibility.
         """
-        return QuadraticProgramToQubo.get_incompatibility(problem)
+        return QuadraticProgramToQubo.get_compatibility_msg(problem)
 
     def solve(self, problem: QuadraticProgram) -> OptimizationResult:
         """Tries to solves the given problem using the optimizer.

--- a/qiskit/optimization/algorithms/grover_minimum_finder.py
+++ b/qiskit/optimization/algorithms/grover_minimum_finder.py
@@ -21,9 +21,9 @@ import math
 import numpy as np
 from qiskit.aqua import QuantumInstance
 from qiskit.optimization.algorithms import OptimizationAlgorithm
-from qiskit.optimization.problems import OptimizationProblem
-from qiskit.optimization.converters import (OptimizationProblemToQubo,
-                                            OptimizationProblemToNegativeValueOracle)
+from qiskit.optimization.problems import QuadraticProgram
+from qiskit.optimization.converters import (QuadraticProgramToQubo,
+                                            QuadraticProgramToNegativeValueOracle)
 from qiskit.optimization.results import GroverOptimizationResults
 from qiskit.optimization.results import OptimizationResult
 from qiskit.optimization.util import get_qubo_solutions
@@ -52,7 +52,7 @@ class GroverMinimumFinder(OptimizationAlgorithm):
             quantum_instance = QuantumInstance(backend)
         self._quantum_instance = quantum_instance
 
-    def get_incompatibility(self, problem: OptimizationProblem) -> str:
+    def get_incompatibility(self, problem: QuadraticProgram) -> str:
         """Checks whether a given problem can be solved with this optimizer.
 
         Checks whether the given problem is compatible, i.e., whether the problem can be converted
@@ -64,9 +64,9 @@ class GroverMinimumFinder(OptimizationAlgorithm):
         Returns:
             A message describing the incompatibility.
         """
-        return OptimizationProblemToQubo.get_incompatibility(problem)
+        return QuadraticProgramToQubo.get_incompatibility(problem)
 
-    def solve(self, problem: OptimizationProblem) -> OptimizationResult:
+    def solve(self, problem: QuadraticProgram) -> OptimizationResult:
         """Tries to solves the given problem using the optimizer.
 
         Runs the optimizer to try to solve the optimization problem. If problem is not convex,
@@ -81,8 +81,9 @@ class GroverMinimumFinder(OptimizationAlgorithm):
         Raises:
             QiskitOptimizationError: If the problem is incompatible with the optimizer.
         """
+
         # convert problem to QUBO, this implicitly checks if the problem is compatible
-        qubo_converter = OptimizationProblemToQubo()
+        qubo_converter = QuadraticProgramToQubo()
         problem_ = qubo_converter.encode(problem)
 
         # TODO: How to get from Optimization Problem?
@@ -112,8 +113,8 @@ class GroverMinimumFinder(OptimizationAlgorithm):
         # Initialize oracle helper object.
         orig_constant = problem_.objective.get_offset()
         measurement = not self._quantum_instance.is_statevector
-        opt_prob_converter = OptimizationProblemToNegativeValueOracle(n_value,
-                                                                      measurement)
+        opt_prob_converter = QuadraticProgramToNegativeValueOracle(n_value,
+                                                                   measurement)
 
         while not optimum_found:
             m = 1

--- a/qiskit/optimization/algorithms/grover_minimum_finder.py
+++ b/qiskit/optimization/algorithms/grover_minimum_finder.py
@@ -52,7 +52,7 @@ class GroverMinimumFinder(OptimizationAlgorithm):
             quantum_instance = QuantumInstance(backend)
         self._quantum_instance = quantum_instance
 
-    def is_compatible(self, problem: OptimizationProblem) -> bool:
+    def get_incompatibility(self, problem: OptimizationProblem) -> str:
         """Checks whether a given problem can be solved with this optimizer.
 
         Checks whether the given problem is compatible, i.e., whether the problem can be converted
@@ -62,9 +62,9 @@ class GroverMinimumFinder(OptimizationAlgorithm):
             problem: The optimization problem to check compatibility.
 
         Returns:
-            True, if the problem is compatible and else raise an error.
+            A message describing the incompatibility.
         """
-        return OptimizationProblemToQubo.is_compatible(problem)
+        return OptimizationProblemToQubo.get_incompatibility(problem)
 
     def solve(self, problem: OptimizationProblem) -> OptimizationResult:
         """Tries to solves the given problem using the optimizer.

--- a/qiskit/optimization/algorithms/minimum_eigen_optimizer.py
+++ b/qiskit/optimization/algorithms/minimum_eigen_optimizer.py
@@ -103,7 +103,7 @@ class MinimumEigenOptimizer(OptimizationAlgorithm):
         self._min_eigen_solver = min_eigen_solver
         self._penalty = penalty
 
-    def is_compatible(self, problem: OptimizationProblem) -> Optional[str]:
+    def get_incompatibility(self, problem: OptimizationProblem) -> str:
         """Checks whether a given problem can be solved with this optimizer.
 
         Checks whether the given problem is compatible, i.e., whether the problem can be converted
@@ -113,9 +113,9 @@ class MinimumEigenOptimizer(OptimizationAlgorithm):
             problem: The optimization problem to check compatibility.
 
         Returns:
-            True, if the problem is compatible and else raise an error.
+            A message describing the incompatibility.
         """
-        return OptimizationProblemToQubo.is_compatible(problem)
+        return OptimizationProblemToQubo.get_incompatibility(problem)
 
     def solve(self, problem: OptimizationProblem) -> MinimumEigenOptimizerResult:
         """Tries to solves the given problem using the optimizer.

--- a/qiskit/optimization/algorithms/minimum_eigen_optimizer.py
+++ b/qiskit/optimization/algorithms/minimum_eigen_optimizer.py
@@ -21,10 +21,10 @@ import numpy as np
 from qiskit.aqua.algorithms import MinimumEigensolver
 
 from .optimization_algorithm import OptimizationAlgorithm
-from ..problems.optimization_problem import OptimizationProblem
+from ..problems.quadratic_program import QuadraticProgram
 from ..utils.eigenvector_to_solutions import eigenvector_to_solutions
-from ..converters.optimization_problem_to_operator import OptimizationProblemToOperator
-from ..converters.optimization_problem_to_qubo import OptimizationProblemToQubo
+from ..converters.quadratic_program_to_operator import QuadraticProgramToOperator
+from ..converters.quadratic_program_to_qubo import QuadraticProgramToQubo
 from ..results.optimization_result import OptimizationResult
 
 
@@ -79,7 +79,7 @@ class MinimumEigenOptimizer(OptimizationAlgorithm):
     Hamiltonian to find a good solution for the optimization problem.
 
     Examples:
-        >>> problem = OptimizationProblem()
+        >>> problem = QuadraticProgram()
         >>> # specify problem here
         >>> # specify minimum eigen solver to be used, e.g., QAOA
         >>> qaoa = QAOA(...)
@@ -103,7 +103,7 @@ class MinimumEigenOptimizer(OptimizationAlgorithm):
         self._min_eigen_solver = min_eigen_solver
         self._penalty = penalty
 
-    def get_incompatibility(self, problem: OptimizationProblem) -> str:
+    def get_incompatibility(self, problem: QuadraticProgram) -> str:
         """Checks whether a given problem can be solved with this optimizer.
 
         Checks whether the given problem is compatible, i.e., whether the problem can be converted
@@ -115,9 +115,9 @@ class MinimumEigenOptimizer(OptimizationAlgorithm):
         Returns:
             A message describing the incompatibility.
         """
-        return OptimizationProblemToQubo.get_incompatibility(problem)
+        return QuadraticProgramToQubo.get_incompatibility(problem)
 
-    def solve(self, problem: OptimizationProblem) -> MinimumEigenOptimizerResult:
+    def solve(self, problem: QuadraticProgram) -> MinimumEigenOptimizerResult:
         """Tries to solves the given problem using the optimizer.
 
         Runs the optimizer to try to solve the optimization problem.
@@ -128,12 +128,12 @@ class MinimumEigenOptimizer(OptimizationAlgorithm):
         Returns:
             The result of the optimizer applied to the problem.
         """
-        # convert problem to QUBO, this implicitly checks if the problem is compatible
-        qubo_converter = OptimizationProblemToQubo()
+        # convert problem to QUBO
+        qubo_converter = QuadraticProgramToQubo()
         problem_ = qubo_converter.encode(problem)
 
         # construct operator and offset
-        operator_converter = OptimizationProblemToOperator()
+        operator_converter = QuadraticProgramToOperator()
         operator, offset = operator_converter.encode(problem_)
 
         # approximate ground state of operator using min eigen solver

--- a/qiskit/optimization/algorithms/minimum_eigen_optimizer.py
+++ b/qiskit/optimization/algorithms/minimum_eigen_optimizer.py
@@ -113,7 +113,7 @@ class MinimumEigenOptimizer(OptimizationAlgorithm):
             problem: The optimization problem to check compatibility.
 
         Returns:
-            Returns ``None`` if the problem is compatible and else a string with the error message.
+            True, if the problem is compatible and else raise an error.
         """
         return OptimizationProblemToQubo.is_compatible(problem)
 
@@ -127,10 +127,8 @@ class MinimumEigenOptimizer(OptimizationAlgorithm):
 
         Returns:
             The result of the optimizer applied to the problem.
-
         """
-
-        # convert problem to QUBO
+        # convert problem to QUBO, this implicitly checks if the problem is compatible
         qubo_converter = OptimizationProblemToQubo()
         problem_ = qubo_converter.encode(problem)
 

--- a/qiskit/optimization/algorithms/minimum_eigen_optimizer.py
+++ b/qiskit/optimization/algorithms/minimum_eigen_optimizer.py
@@ -103,7 +103,7 @@ class MinimumEigenOptimizer(OptimizationAlgorithm):
         self._min_eigen_solver = min_eigen_solver
         self._penalty = penalty
 
-    def get_incompatibility(self, problem: QuadraticProgram) -> str:
+    def get_compatibility_msg(self, problem: QuadraticProgram) -> str:
         """Checks whether a given problem can be solved with this optimizer.
 
         Checks whether the given problem is compatible, i.e., whether the problem can be converted
@@ -115,7 +115,7 @@ class MinimumEigenOptimizer(OptimizationAlgorithm):
         Returns:
             A message describing the incompatibility.
         """
-        return QuadraticProgramToQubo.get_incompatibility(problem)
+        return QuadraticProgramToQubo.get_compatibility_msg(problem)
 
     def solve(self, problem: QuadraticProgram) -> MinimumEigenOptimizerResult:
         """Tries to solves the given problem using the optimizer.

--- a/qiskit/optimization/algorithms/optimization_algorithm.py
+++ b/qiskit/optimization/algorithms/optimization_algorithm.py
@@ -25,7 +25,7 @@ class OptimizationAlgorithm(ABC):
     """An abstract class for optimization algorithms in Qiskit Optimization."""
 
     @abstractmethod
-    def get_incompatibility(self, problem: QuadraticProgram) -> str:
+    def get_compatibility_msg(self, problem: QuadraticProgram) -> str:
         """Checks whether a given problem can be solved with the optimizer implementing this method.
 
         Args:
@@ -44,7 +44,7 @@ class OptimizationAlgorithm(ABC):
         Returns:
             Returns True if the problem is compatible, False otherwise.
         """
-        return len(self.get_incompatibility(problem)) > 0
+        return len(self.get_compatibility_msg(problem)) > 0
 
     @abstractmethod
     def solve(self, problem: QuadraticProgram) -> OptimizationResult:

--- a/qiskit/optimization/algorithms/optimization_algorithm.py
+++ b/qiskit/optimization/algorithms/optimization_algorithm.py
@@ -17,7 +17,7 @@
 
 from abc import ABC, abstractmethod
 
-from ..problems.optimization_problem import OptimizationProblem
+from ..problems.quadratic_program import QuadraticProgram
 from ..results.optimization_result import OptimizationResult
 
 
@@ -25,7 +25,7 @@ class OptimizationAlgorithm(ABC):
     """An abstract class for optimization algorithms in Qiskit Optimization."""
 
     @abstractmethod
-    def get_incompatibility(self, problem: OptimizationProblem) -> str:
+    def get_incompatibility(self, problem: QuadraticProgram) -> str:
         """Checks whether a given problem can be solved with the optimizer implementing this method.
 
         Args:
@@ -35,7 +35,7 @@ class OptimizationAlgorithm(ABC):
             Returns the incompatibility message. If the message is empty no issues were found.
         """
 
-    def is_compatible(self, problem: OptimizationProblem) -> bool:
+    def is_compatible(self, problem: QuadraticProgram) -> bool:
         """Checks whether a given problem can be solved with the optimizer implementing this method.
 
         Args:
@@ -47,7 +47,7 @@ class OptimizationAlgorithm(ABC):
         return len(self.get_incompatibility(problem)) > 0
 
     @abstractmethod
-    def solve(self, problem: OptimizationProblem) -> OptimizationResult:
+    def solve(self, problem: QuadraticProgram) -> OptimizationResult:
         """Tries to solves the given problem using the optimizer.
 
         Runs the optimizer to try to solve the optimization problem.

--- a/qiskit/optimization/algorithms/optimization_algorithm.py
+++ b/qiskit/optimization/algorithms/optimization_algorithm.py
@@ -25,6 +25,16 @@ class OptimizationAlgorithm(ABC):
     """An abstract class for optimization algorithms in Qiskit Optimization."""
 
     @abstractmethod
+    def get_incompatibility(self, problem: OptimizationProblem) -> str:
+        """Checks whether a given problem can be solved with the optimizer implementing this method.
+
+        Args:
+            problem: The optimization problem to check compatibility.
+
+        Returns:
+            Returns the incompatibility message. If the message is empty no issues were found.
+        """
+
     def is_compatible(self, problem: OptimizationProblem) -> bool:
         """Checks whether a given problem can be solved with the optimizer implementing this method.
 
@@ -32,9 +42,9 @@ class OptimizationAlgorithm(ABC):
             problem: The optimization problem to check compatibility.
 
         Returns:
-            Returns True if the problem is compatible, otherwise raises an error.
+            Returns True if the problem is compatible, False otherwise.
         """
-        raise NotImplementedError
+        return len(self.get_incompatibility(problem)) > 0
 
     @abstractmethod
     def solve(self, problem: OptimizationProblem) -> OptimizationResult:

--- a/qiskit/optimization/algorithms/optimization_algorithm.py
+++ b/qiskit/optimization/algorithms/optimization_algorithm.py
@@ -17,8 +17,6 @@
 
 from abc import ABC, abstractmethod
 
-from typing import Optional
-
 from ..problems.optimization_problem import OptimizationProblem
 from ..results.optimization_result import OptimizationResult
 
@@ -27,14 +25,14 @@ class OptimizationAlgorithm(ABC):
     """An abstract class for optimization algorithms in Qiskit Optimization."""
 
     @abstractmethod
-    def is_compatible(self, problem: OptimizationProblem) -> Optional[str]:
+    def is_compatible(self, problem: OptimizationProblem) -> bool:
         """Checks whether a given problem can be solved with the optimizer implementing this method.
 
         Args:
             problem: The optimization problem to check compatibility.
 
         Returns:
-            Returns ``None`` if the problem is compatible and else a string with the error message.
+            Returns True if the problem is compatible, otherwise raises an error.
         """
         raise NotImplementedError
 

--- a/qiskit/optimization/algorithms/optimization_algorithm.py
+++ b/qiskit/optimization/algorithms/optimization_algorithm.py
@@ -44,7 +44,7 @@ class OptimizationAlgorithm(ABC):
         Returns:
             Returns True if the problem is compatible, False otherwise.
         """
-        return len(self.get_compatibility_msg(problem)) > 0
+        return len(self.get_compatibility_msg(problem)) == 0
 
     @abstractmethod
     def solve(self, problem: QuadraticProgram) -> OptimizationResult:

--- a/qiskit/optimization/algorithms/recursive_minimum_eigen_optimizer.py
+++ b/qiskit/optimization/algorithms/recursive_minimum_eigen_optimizer.py
@@ -94,7 +94,7 @@ class RecursiveMinimumEigenOptimizer(OptimizationAlgorithm):
             self._min_num_vars_optimizer = MinimumEigenOptimizer(NumPyMinimumEigensolver())
         self._penalty = penalty
 
-    def is_compatible(self, problem: OptimizationProblem) -> Optional[str]:
+    def is_compatible(self, problem: OptimizationProblem) -> bool:
         """Checks whether a given problem can be solved with this optimizer.
 
         Checks whether the given problem is compatible, i.e., whether the problem can be converted
@@ -104,7 +104,7 @@ class RecursiveMinimumEigenOptimizer(OptimizationAlgorithm):
             problem: The optimization problem to check compatibility.
 
         Returns:
-            Returns ``None`` if the problem is compatible and else a string with the error message.
+            True, if the problem is compatible and else raise an error.
         """
         return OptimizationProblemToQubo.is_compatible(problem)
 
@@ -121,9 +121,8 @@ class RecursiveMinimumEigenOptimizer(OptimizationAlgorithm):
 
         Raises:
             QiskitOptimizationError: Infeasible due to variable substitution
-
         """
-        # convert problem to QUBO
+        # convert problem to QUBO, this implicitly checks if the problem is compatible
         qubo_converter = OptimizationProblemToQubo()
         problem_ = qubo_converter.encode(problem)
         problem_ref = deepcopy(problem_)

--- a/qiskit/optimization/algorithms/recursive_minimum_eigen_optimizer.py
+++ b/qiskit/optimization/algorithms/recursive_minimum_eigen_optimizer.py
@@ -94,7 +94,7 @@ class RecursiveMinimumEigenOptimizer(OptimizationAlgorithm):
             self._min_num_vars_optimizer = MinimumEigenOptimizer(NumPyMinimumEigensolver())
         self._penalty = penalty
 
-    def get_incompatibility(self, problem: QuadraticProgram) -> str:
+    def get_compatibility_msg(self, problem: QuadraticProgram) -> str:
         """Checks whether a given problem can be solved with this optimizer.
 
         Checks whether the given problem is compatible, i.e., whether the problem can be converted
@@ -106,7 +106,7 @@ class RecursiveMinimumEigenOptimizer(OptimizationAlgorithm):
         Returns:
             A message describing the incompatibility.
         """
-        return QuadraticProgramToQubo.get_incompatibility(problem)
+        return QuadraticProgramToQubo.get_compatibility_msg(problem)
 
     def solve(self, problem: QuadraticProgram) -> OptimizationResult:
         """Tries to solves the given problem using the recursive optimizer.

--- a/qiskit/optimization/algorithms/recursive_minimum_eigen_optimizer.py
+++ b/qiskit/optimization/algorithms/recursive_minimum_eigen_optimizer.py
@@ -15,7 +15,7 @@
 """A recursive minimal eigen optimizer in Qiskit Optimization.
 
     Examples:
-        >>> problem = OptimizationProblem()
+        >>> problem = QuadraticProgram()
         >>> # specify problem here
         >>> # specify minimum eigen solver to be used, e.g., QAOA
         >>> qaoa = QAOA(...)
@@ -34,9 +34,9 @@ from qiskit.aqua.utils.validation import validate_min
 from .optimization_algorithm import OptimizationAlgorithm
 from .minimum_eigen_optimizer import MinimumEigenOptimizer
 from ..utils.qiskit_optimization_error import QiskitOptimizationError
-from ..problems.optimization_problem import OptimizationProblem
+from ..problems.quadratic_program import QuadraticProgram
 from ..results.optimization_result import OptimizationResult
-from ..converters.optimization_problem_to_qubo import OptimizationProblemToQubo
+from ..converters.quadratic_program_to_qubo import QuadraticProgramToQubo
 
 logger = logging.getLogger(__name__)
 
@@ -94,7 +94,7 @@ class RecursiveMinimumEigenOptimizer(OptimizationAlgorithm):
             self._min_num_vars_optimizer = MinimumEigenOptimizer(NumPyMinimumEigensolver())
         self._penalty = penalty
 
-    def get_incompatibility(self, problem: OptimizationProblem) -> str:
+    def get_incompatibility(self, problem: QuadraticProgram) -> str:
         """Checks whether a given problem can be solved with this optimizer.
 
         Checks whether the given problem is compatible, i.e., whether the problem can be converted
@@ -106,9 +106,9 @@ class RecursiveMinimumEigenOptimizer(OptimizationAlgorithm):
         Returns:
             A message describing the incompatibility.
         """
-        return OptimizationProblemToQubo.get_incompatibility(problem)
+        return QuadraticProgramToQubo.get_incompatibility(problem)
 
-    def solve(self, problem: OptimizationProblem) -> OptimizationResult:
+    def solve(self, problem: QuadraticProgram) -> OptimizationResult:
         """Tries to solves the given problem using the recursive optimizer.
 
         Runs the optimizer to try to solve the optimization problem.
@@ -123,7 +123,7 @@ class RecursiveMinimumEigenOptimizer(OptimizationAlgorithm):
             QiskitOptimizationError: Infeasible due to variable substitution
         """
         # convert problem to QUBO, this implicitly checks if the problem is compatible
-        qubo_converter = OptimizationProblemToQubo()
+        qubo_converter = QuadraticProgramToQubo()
         problem_ = qubo_converter.encode(problem)
         problem_ref = deepcopy(problem_)
 

--- a/qiskit/optimization/algorithms/recursive_minimum_eigen_optimizer.py
+++ b/qiskit/optimization/algorithms/recursive_minimum_eigen_optimizer.py
@@ -94,7 +94,7 @@ class RecursiveMinimumEigenOptimizer(OptimizationAlgorithm):
             self._min_num_vars_optimizer = MinimumEigenOptimizer(NumPyMinimumEigensolver())
         self._penalty = penalty
 
-    def is_compatible(self, problem: OptimizationProblem) -> bool:
+    def get_incompatibility(self, problem: OptimizationProblem) -> str:
         """Checks whether a given problem can be solved with this optimizer.
 
         Checks whether the given problem is compatible, i.e., whether the problem can be converted
@@ -104,9 +104,9 @@ class RecursiveMinimumEigenOptimizer(OptimizationAlgorithm):
             problem: The optimization problem to check compatibility.
 
         Returns:
-            True, if the problem is compatible and else raise an error.
+            A message describing the incompatibility.
         """
-        return OptimizationProblemToQubo.is_compatible(problem)
+        return OptimizationProblemToQubo.get_incompatibility(problem)
 
     def solve(self, problem: OptimizationProblem) -> OptimizationResult:
         """Tries to solves the given problem using the recursive optimizer.

--- a/qiskit/optimization/converters/__init__.py
+++ b/qiskit/optimization/converters/__init__.py
@@ -24,18 +24,18 @@ Structures for converting optimization problems
 
 """
 
-from .optimization_problem_to_negative_value_oracle import OptimizationProblemToNegativeValueOracle
+from .quadratic_program_to_negative_value_oracle import QuadraticProgramToNegativeValueOracle
 from .inequality_to_equality_converter import InequalityToEqualityConverter
 from .integer_to_binary_converter import IntegerToBinaryConverter
-from .optimization_problem_to_operator import OptimizationProblemToOperator
+from .quadratic_program_to_operator import QuadraticProgramToOperator
 from .penalize_linear_equality_constraints import PenalizeLinearEqualityConstraints
-from .optimization_problem_to_qubo import OptimizationProblemToQubo
+from .quadratic_program_to_qubo import QuadraticProgramToQubo
 
 __all__ = [
     "InequalityToEqualityConverter",
     "IntegerToBinaryConverter",
-    "OptimizationProblemToNegativeValueOracle",
-    "OptimizationProblemToOperator",
-    "OptimizationProblemToQubo",
+    "QuadraticProgramToNegativeValueOracle",
+    "QuadraticProgramToOperator",
+    "QuadraticProgramToQubo",
     "PenalizeLinearEqualityConstraints",
 ]

--- a/qiskit/optimization/converters/inequality_to_equality_converter.py
+++ b/qiskit/optimization/converters/inequality_to_equality_converter.py
@@ -19,7 +19,7 @@ import math
 from typing import List, Tuple, Dict, Optional
 import logging
 
-from ..problems.optimization_problem import OptimizationProblem
+from ..problems.quadratic_program import QuadraticProgram
 from ..results.optimization_result import OptimizationResult
 from ..utils.qiskit_optimization_error import QiskitOptimizationError
 
@@ -37,7 +37,7 @@ class InequalityToEqualityConverter:
     """Convert inequality constraints into equality constraints by introducing slack variables.
 
     Examples:
-        >>> problem = OptimizationProblem()
+        >>> problem = QuadraticProgram()
         >>> # define a problem
         >>> conv = InequalityToEqualityConverter()
         >>> problem2 = conv.encode(problem)
@@ -55,8 +55,8 @@ class InequalityToEqualityConverter:
         self._conv: Dict[str, List[Tuple[str, int]]] = {}
         # e.g., self._conv = {'c1': [c1@slack_var]}
 
-    def encode(self, op: OptimizationProblem, name: Optional[str] = None,
-               mode: str = 'auto') -> OptimizationProblem:
+    def encode(self, op: QuadraticProgram, name: Optional[str] = None,
+               mode: str = 'auto') -> QuadraticProgram:
         """Convert a problem with inequality constraints into one with only equality constraints.
 
         Args:
@@ -77,7 +77,7 @@ class InequalityToEqualityConverter:
             QiskitOptimizationError: If an unsupported sense is specified.
         """
         self._src = copy.deepcopy(op)
-        self._dst = OptimizationProblem()
+        self._dst = QuadraticProgram()
 
         # declare variables
         names = self._src.variables.get_names()

--- a/qiskit/optimization/converters/integer_to_binary_converter.py
+++ b/qiskit/optimization/converters/integer_to_binary_converter.py
@@ -19,7 +19,7 @@ from typing import Dict, List, Optional, Tuple
 import logging
 import numpy as np
 
-from ..problems.optimization_problem import OptimizationProblem
+from ..problems.quadratic_program import QuadraticProgram
 from ..results.optimization_result import OptimizationResult
 from ..utils.qiskit_optimization_error import QiskitOptimizationError
 
@@ -34,10 +34,10 @@ except ImportError:
 
 
 class IntegerToBinaryConverter:
-    """Convert an `OptimizationProblem` into new one by encoding integer with binary variables.
+    """Convert an `QuadraticProgram` into new one by encoding integer with binary variables.
 
     Examples:
-        >>> problem = OptimizationProblem()
+        >>> problem = QuadraticProgram()
         >>> problem.variables.add(names=['x'], types=['I'], lb=[0], ub=[10])
         >>> conv = IntegerToBinaryConverter()
         >>> problem2 = conv.encode(problem)
@@ -55,7 +55,7 @@ class IntegerToBinaryConverter:
         self._conv: Dict[str, List[Tuple[str, int]]] = {}
         # e.g., self._conv = {'x': [('x@1', 1), ('x@2', 2)]}
 
-    def encode(self, op: OptimizationProblem, name: Optional[str] = None) -> OptimizationProblem:
+    def encode(self, op: QuadraticProgram, name: Optional[str] = None) -> QuadraticProgram:
         """Convert an integer problem into a new problem with binary variables.
 
         Args:
@@ -68,7 +68,7 @@ class IntegerToBinaryConverter:
         """
 
         self._src = copy.deepcopy(op)
-        self._dst = OptimizationProblem()
+        self._dst = QuadraticProgram()
         if name:
             self._dst.set_problem_name(name)
         else:

--- a/qiskit/optimization/converters/optimization_problem_to_qubo.py
+++ b/qiskit/optimization/converters/optimization_problem_to_qubo.py
@@ -59,9 +59,8 @@ class OptimizationProblemToQubo:
         """
 
         # analyze compatibility of problem
-        msg = self.is_compatible(problem)
-        if msg is not None:
-            raise QiskitOptimizationError('Incompatible problem: %s' % msg)
+        if not self.is_compatible(problem):
+            raise QiskitOptimizationError('Incompatible problem.')
 
         # map integer variables to binary variables
         problem_ = self._int_to_bin.encode(problem)
@@ -89,18 +88,22 @@ class OptimizationProblemToQubo:
         return self._int_to_bin.decode(result)
 
     @staticmethod
-    def is_compatible(problem: OptimizationProblem) -> Optional[str]:
-        """Checks whether a given problem can be cast to a Quadratic Unconstrained Binary
-        Optimization (QUBO) problem, i.e., whether the problem contains only binary and integer
-        variables as well as linear equality constraints, and otherwise, returns a message
-        explaining the incompatibility.
+    def is_compatible(problem: OptimizationProblem) -> bool:
+        """Checks whether a given problem can be cast to a QUBO.
+
+        An optimization problem can be converted to a QUBO (Quadratic Unconstrained Binary
+        Optimization) problem, if the problem contains only binary and integer variables as well
+        as linear equality constraints.
 
         Args:
             problem: The optimization problem to check compatibility.
 
         Returns:
-            Returns ``None`` if the problem is compatible and else a string with the error message.
+            True, if the problem can be converted to a QUBO, otherwise a QiskitOptimizationError
+            is raised.
 
+        Raises:
+            QiskitOptimizationError: If the conversion to QUBO is not possible.
         """
 
         # initialize message
@@ -124,6 +127,6 @@ class OptimizationProblemToQubo:
 
         # if an error occurred, return error message, otherwise, return None
         if len(msg) > 0:
-            return msg.strip()
-        else:
-            return None
+            raise QiskitOptimizationError('Cannot convert the problem to QUBO: %s' % msg)
+
+        return True

--- a/qiskit/optimization/converters/optimization_problem_to_qubo.py
+++ b/qiskit/optimization/converters/optimization_problem_to_qubo.py
@@ -88,7 +88,7 @@ class OptimizationProblemToQubo:
         return self._int_to_bin.decode(result)
 
     @staticmethod
-    def is_compatible(problem: OptimizationProblem) -> bool:
+    def get_incompatibility(problem: OptimizationProblem) -> bool:
         """Checks whether a given problem can be cast to a QUBO.
 
         An optimization problem can be converted to a QUBO (Quadratic Unconstrained Binary
@@ -126,7 +126,15 @@ class OptimizationProblemToQubo:
             msg += 'Quadratic constraints are not supported. '
 
         # if an error occurred, return error message, otherwise, return None
-        if len(msg) > 0:
-            raise QiskitOptimizationError('Cannot convert the problem to QUBO: %s' % msg)
+        return msg
 
-        return True
+    def is_compatible(self, problem: OptimizationProblem) -> bool:
+        """Checks whether a given problem can be solved with the optimizer implementing this method.
+
+        Args:
+            problem: The optimization problem to check compatibility.
+
+        Returns:
+            Returns True if the problem is compatible, False otherwise.
+        """
+        return len(self.get_incompatibility(problem)) > 0

--- a/qiskit/optimization/converters/penalize_linear_equality_constraints.py
+++ b/qiskit/optimization/converters/penalize_linear_equality_constraints.py
@@ -19,7 +19,7 @@ from typing import Optional
 import copy
 from collections import defaultdict
 
-from ..problems.optimization_problem import OptimizationProblem
+from ..problems.quadratic_program import QuadraticProgram
 from ..utils.qiskit_optimization_error import QiskitOptimizationError
 
 
@@ -31,8 +31,8 @@ class PenalizeLinearEqualityConstraints:
         self._src = None
         self._dst = None
 
-    def encode(self, op: OptimizationProblem, penalty_factor: float = 1e5,
-               name: Optional[str] = None) -> OptimizationProblem:
+    def encode(self, op: QuadraticProgram, penalty_factor: float = 1e5,
+               name: Optional[str] = None) -> QuadraticProgram:
         """Convert a problem with equality constraints into an unconstrained problem.
 
         Args:
@@ -49,9 +49,9 @@ class PenalizeLinearEqualityConstraints:
 
         # TODO: test compatibility, how to react in case of incompatibility?
 
-        # create empty OptimizationProblem model
+        # create empty QuadraticProgram model
         self._src = copy.deepcopy(op)  # deep copy
-        self._dst = OptimizationProblem()
+        self._dst = QuadraticProgram()
 
         # set variables (obj is set via objective interface)
         var_names = self._src.variables.get_names()

--- a/qiskit/optimization/converters/quadratic_program_to_negative_value_oracle.py
+++ b/qiskit/optimization/converters/quadratic_program_to_negative_value_oracle.py
@@ -12,7 +12,7 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
-"""OptimizationProblemToNegativeValueOracle module"""
+"""QuadraticProgramToNegativeValueOracle module"""
 
 import logging
 from typing import Tuple, Dict, Union
@@ -23,12 +23,12 @@ from qiskit import QuantumCircuit, QuantumRegister, ClassicalRegister
 from qiskit.aqua.components.initial_states import Custom
 from qiskit.aqua.components.iqfts import Standard as IQFT
 from qiskit.aqua.components.oracles import CustomCircuitOracle
-from qiskit.optimization.problems import OptimizationProblem
+from qiskit.optimization.problems import QuadraticProgram
 
 logger = logging.getLogger(__name__)
 
 
-class OptimizationProblemToNegativeValueOracle:
+class QuadraticProgramToNegativeValueOracle:
     """Converts an optimization problem (QUBO) to a negative value oracle.
 
     In addition, a state preparation operator is generated from the coefficients and constant of a
@@ -46,7 +46,7 @@ class OptimizationProblemToNegativeValueOracle:
         self._num_value = num_output_qubits
         self._measurement = measurement
 
-    def encode(self, problem: OptimizationProblem) -> \
+    def encode(self, problem: QuadraticProgram) -> \
             Tuple[Custom, CustomCircuitOracle, Dict[Union[int, Tuple[int, int]], int]]:
         """A helper function that converts a QUBO into an oracle that recognizes negative numbers.
 

--- a/qiskit/optimization/converters/quadratic_program_to_operator.py
+++ b/qiskit/optimization/converters/quadratic_program_to_operator.py
@@ -13,7 +13,7 @@
 # that they have been altered from the originals.
 
 
-"""The converter from an ```OptimizationProblem``` to ``Operator``."""
+"""The converter from an ```QuadraticProgram``` to ``Operator``."""
 
 from typing import Dict, Tuple
 
@@ -22,11 +22,11 @@ from qiskit.quantum_info import Pauli
 
 from qiskit.aqua.operators import WeightedPauliOperator
 
-from ..problems.optimization_problem import OptimizationProblem
+from ..problems.quadratic_program import QuadraticProgram
 from ..utils.qiskit_optimization_error import QiskitOptimizationError
 
 
-class OptimizationProblemToOperator:
+class QuadraticProgramToOperator:
     """Convert an optimization problem into a qubit operator."""
 
     def __init__(self) -> None:
@@ -35,7 +35,7 @@ class OptimizationProblemToOperator:
         self._q_d: Dict[int, int] = {}
         # e.g., self._q_d = {0: 0}
 
-    def encode(self, op: OptimizationProblem) -> Tuple[WeightedPauliOperator, float]:
+    def encode(self, op: QuadraticProgram) -> Tuple[WeightedPauliOperator, float]:
         """Convert a problem into a qubit operator
 
         Args:

--- a/qiskit/optimization/converters/quadratic_program_to_qubo.py
+++ b/qiskit/optimization/converters/quadratic_program_to_qubo.py
@@ -56,8 +56,9 @@ class QuadraticProgramToQubo:
         """
 
         # analyze compatibility of problem
-        if not self.is_compatible(problem):
-            raise QiskitOptimizationError('Incompatible problem.')
+        msg = self.get_compatibility_msg(problem)
+        if len(msg) > 0:
+            raise QiskitOptimizationError('Incompatible problem: {}'.format(msg))
 
         # map integer variables to binary variables
         problem_ = self._int_to_bin.encode(problem)
@@ -134,4 +135,4 @@ class QuadraticProgramToQubo:
         Returns:
             Returns True if the problem is compatible, False otherwise.
         """
-        return len(self.get_compatibility_msg(problem)) > 0
+        return len(self.get_compatibility_msg(problem)) == 0

--- a/qiskit/optimization/converters/quadratic_program_to_qubo.py
+++ b/qiskit/optimization/converters/quadratic_program_to_qubo.py
@@ -85,7 +85,7 @@ class QuadraticProgramToQubo:
         return self._int_to_bin.decode(result)
 
     @staticmethod
-    def get_incompatibility(problem: QuadraticProgram) -> bool:
+    def get_compatibility_msg(problem: QuadraticProgram) -> bool:
         """Checks whether a given problem can be cast to a QUBO.
 
         A quadratic program can be converted to a QUBO (Quadratic Unconstrained Binary
@@ -134,4 +134,4 @@ class QuadraticProgramToQubo:
         Returns:
             Returns True if the problem is compatible, False otherwise.
         """
-        return len(self.get_incompatibility(problem)) > 0
+        return len(self.get_compatibility_msg(problem)) > 0

--- a/qiskit/optimization/converters/quadratic_program_to_qubo.py
+++ b/qiskit/optimization/converters/quadratic_program_to_qubo.py
@@ -12,31 +12,29 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
-"""A converter from optimization problem to a QUBO (given as optimization problem).
-"""
+"""A converter from quadratic program to a QUBO."""
 
 from typing import Optional
 
-from qiskit.optimization.problems import OptimizationProblem
+from qiskit.optimization.problems import QuadraticProgram
 from qiskit.optimization.results import OptimizationResult
 from qiskit.optimization.converters import (PenalizeLinearEqualityConstraints,
                                             IntegerToBinaryConverter)
 from qiskit.optimization.utils import QiskitOptimizationError
 
 
-class OptimizationProblemToQubo:
-    """ Convert a given optimization problem to a new problem that is a QUBO.
+class QuadraticProgramToQubo:
+    """Convert a given optimization problem to a new problem that is a QUBO.
 
         Examples:
-            >>> problem = OptimizationProblem()
+            >>> problem = QuadraticProgram()
             >>> # define a problem
-            >>> conv = OptimizationProblemToQubo()
+            >>> conv = QuadraticProgramToQubo()
             >>> problem2 = conv.encode(problem)
     """
 
     def __init__(self, penalty: Optional[float] = 1e5) -> None:
-        """ Constructor. It initializes the internal data structure.
-
+        """
         Args:
             penalty: Penalty factor to scale equality constraints that are added to objective.
         """
@@ -44,8 +42,8 @@ class OptimizationProblemToQubo:
         self._penalize_lin_eq_constraints = PenalizeLinearEqualityConstraints()
         self._penalty = penalty
 
-    def encode(self, problem: OptimizationProblem) -> OptimizationProblem:
-        """ Convert a problem with linear equality constraints into new one with a QUBO form.
+    def encode(self, problem: QuadraticProgram) -> QuadraticProgram:
+        """Convert a problem with linear equality constraints into new one with a QUBO form.
 
         Args:
             problem: The problem with linear equality constraints to be solved.
@@ -55,7 +53,6 @@ class OptimizationProblemToQubo:
 
         Raises:
             QiskitOptimizationError: In case of an incompatible problem.
-
         """
 
         # analyze compatibility of problem
@@ -88,10 +85,10 @@ class OptimizationProblemToQubo:
         return self._int_to_bin.decode(result)
 
     @staticmethod
-    def get_incompatibility(problem: OptimizationProblem) -> bool:
+    def get_incompatibility(problem: QuadraticProgram) -> bool:
         """Checks whether a given problem can be cast to a QUBO.
 
-        An optimization problem can be converted to a QUBO (Quadratic Unconstrained Binary
+        A quadratic program can be converted to a QUBO (Quadratic Unconstrained Binary
         Optimization) problem, if the problem contains only binary and integer variables as well
         as linear equality constraints.
 
@@ -128,7 +125,7 @@ class OptimizationProblemToQubo:
         # if an error occurred, return error message, otherwise, return None
         return msg
 
-    def is_compatible(self, problem: OptimizationProblem) -> bool:
+    def is_compatible(self, problem: QuadraticProgram) -> bool:
         """Checks whether a given problem can be solved with the optimizer implementing this method.
 
         Args:

--- a/qiskit/optimization/problems/__init__.py
+++ b/qiskit/optimization/problems/__init__.py
@@ -29,27 +29,27 @@ Structures for defining an optimization problem and its solution
    LinearConstraintInterface
    ObjSense
    ObjectiveInterface
-   OptimizationProblem
+   QuadraticProgram
    QuadraticConstraintInterface
    VariablesInterface
 
 N.B. Additional classes LinearConstraintInterface, QuadraticConstraintInterface,
 ObjectiveInterface, and VariablesInterface
 are not to be instantiated directly. Objects of those types are available within
-an instantiated OptimizationProblem.
+an instantiated QuadraticProgram.
 
 """
 
 from .linear_constraint import LinearConstraintInterface
 from .objective import ObjSense, ObjectiveInterface
-from .optimization_problem import OptimizationProblem
+from .quadratic_program import QuadraticProgram
 from .quadratic_constraint import QuadraticConstraintInterface
 from .variables import VariablesInterface
 
 __all__ = ['LinearConstraintInterface',
            'ObjSense',
            'ObjectiveInterface',
-           'OptimizationProblem',
+           'QuadraticProgram',
            'QuadraticConstraintInterface',
            'VariablesInterface'
            ]

--- a/qiskit/optimization/problems/linear_constraint.py
+++ b/qiskit/optimization/problems/linear_constraint.py
@@ -40,7 +40,7 @@ class LinearConstraintInterface(BaseInterface):
         """Creates a new LinearConstraintInterface.
 
         The linear constraints interface is exposed by the top-level
-        `OptimizationProblem` class as `OptimizationProblem.linear_constraints`.
+        `QuadraticProgram` class as `QuadraticProgram.linear_constraints`.
         This constructor is not meant to be used externally.
         """
         if not _HAS_CPLEX:
@@ -60,8 +60,8 @@ class LinearConstraintInterface(BaseInterface):
 
         Example usage:
 
-        >>> from qiskit.optimization import OptimizationProblem
-        >>> op = OptimizationProblem()
+        >>> from qiskit.optimization import QuadraticProgram
+        >>> op = QuadraticProgram()
         >>> indices = op.linear_constraints.add(names = ["c1", "c2", "c3"])
         >>> op.linear_constraints.get_num()
         3
@@ -109,8 +109,8 @@ class LinearConstraintInterface(BaseInterface):
         Returns an iterator containing the indices of the added linear
         constraints.
 
-        >>> from qiskit.optimization import OptimizationProblem
-        >>> op = OptimizationProblem()
+        >>> from qiskit.optimization import QuadraticProgram
+        >>> op = QuadraticProgram()
         >>> indices = op.variables.add(names = ["x1", "x2", "x3"])
         >>> indices = op.linear_constraints.add(\
                 lin_expr = [SparsePair(ind = ["x1", "x3"], val = [1.0, -1.0]),\
@@ -199,8 +199,8 @@ class LinearConstraintInterface(BaseInterface):
 
         Example usage:
 
-        >>> from qiskit.optimization import OptimizationProblem
-        >>> op = OptimizationProblem()
+        >>> from qiskit.optimization import QuadraticProgram
+        >>> op = QuadraticProgram()
         >>> indices = op.linear_constraints.add(names=[str(i) for i in range(10)])
         >>> op.linear_constraints.get_num()
         10
@@ -255,8 +255,8 @@ class LinearConstraintInterface(BaseInterface):
           the corresponding values.  Equivalent to
           [linear_constraints.set_rhs(pair[0], pair[1]) for pair in seq_of_pairs].
 
-        >>> from qiskit.optimization import OptimizationProblem
-        >>> op = OptimizationProblem()
+        >>> from qiskit.optimization import QuadraticProgram
+        >>> op = QuadraticProgram()
         >>> indices = op.linear_constraints.add(names = ["c0", "c1", "c2", "c3"])
         >>> op.linear_constraints.get_rhs()
         [0.0, 0.0, 0.0, 0.0]
@@ -290,8 +290,8 @@ class LinearConstraintInterface(BaseInterface):
           corresponding strings.  Equivalent to
           [linear_constraints.set_names(pair[0], pair[1]) for pair in seq_of_pairs].
 
-        >>> from qiskit.optimization import OptimizationProblem
-        >>> op = OptimizationProblem()
+        >>> from qiskit.optimization import QuadraticProgram
+        >>> op = QuadraticProgram()
         >>> indices = op.linear_constraints.add(names = ["c0", "c1", "c2", "c3"])
         >>> op.linear_constraints.set_names("c1", "second")
         >>> op.linear_constraints.get_names(1)
@@ -327,8 +327,8 @@ class LinearConstraintInterface(BaseInterface):
         and 'R', indicating greater-than, less-than, equality, and
         ranged constraints, respectively.
 
-        >>> from qiskit.optimization import OptimizationProblem
-        >>> op = OptimizationProblem()
+        >>> from qiskit.optimization import QuadraticProgram
+        >>> op = QuadraticProgram()
         >>> indices = op.linear_constraints.add(names = ["c0", "c1", "c2", "c3"])
         >>> op.linear_constraints.get_senses()
         ['E', 'E', 'E', 'E']
@@ -367,8 +367,8 @@ class LinearConstraintInterface(BaseInterface):
           to the corresponding vector.  Equivalent to
           [linear_constraints.set_linear_components(pair[0], pair[1]) for pair in seq_of_pairs].
 
-        >>> from qiskit.optimization import OptimizationProblem
-        >>> op = OptimizationProblem()
+        >>> from qiskit.optimization import QuadraticProgram
+        >>> op = QuadraticProgram()
         >>> indices = op.linear_constraints.add(names = ["c0", "c1", "c2", "c3"])
         >>> indices = op.variables.add(names = ["x0", "x1"])
         >>> op.linear_constraints.set_linear_components("c0", [["x0"], [1.0]])
@@ -437,8 +437,8 @@ class LinearConstraintInterface(BaseInterface):
           the corresponding values.  Equivalent to
           [linear_constraints.set_range_values(pair[0], pair[1]) for pair in seq_of_pairs].
 
-        >>> from qiskit.optimization import OptimizationProblem
-        >>> op = OptimizationProblem()
+        >>> from qiskit.optimization import QuadraticProgram
+        >>> op = QuadraticProgram()
         >>> indices = op.linear_constraints.add(names = ["c0", "c1", "c2", "c3"])
         >>> op.linear_constraints.set_range_values("c1", 1.0)
         >>> op.linear_constraints.get_range_values()
@@ -468,8 +468,8 @@ class LinearConstraintInterface(BaseInterface):
           coefficients must be a list of (row, col, val) triples as
           described above.
 
-        >>> from qiskit.optimization import OptimizationProblem
-        >>> op = OptimizationProblem()
+        >>> from qiskit.optimization import QuadraticProgram
+        >>> op = QuadraticProgram()
         >>> indices = op.linear_constraints.add(names = ["c0", "c1", "c2", "c3"])
         >>> indices = op.variables.add(names = ["x0", "x1"])
         >>> op.linear_constraints.set_coefficients("c0", "x1", 1.0)
@@ -515,8 +515,8 @@ class LinearConstraintInterface(BaseInterface):
           indices the members of s.  Equivalent to
           [linear_constraints.get_rhs(i) for i in s]
 
-        >>> from qiskit.optimization import OptimizationProblem
-        >>> op = OptimizationProblem()
+        >>> from qiskit.optimization import QuadraticProgram
+        >>> op = QuadraticProgram()
         >>> indices = op.linear_constraints.add(rhs = [1.5 * i for i in range(10)],\
                                      names = [str(i) for i in range(10)])
         >>> op.linear_constraints.get_num()
@@ -556,8 +556,8 @@ class LinearConstraintInterface(BaseInterface):
           the members of s.  Equivalent to
           [linear_constraints.get_senses(i) for i in s]
 
-        >>> from qiskit.optimization import OptimizationProblem
-        >>> op = OptimizationProblem()
+        >>> from qiskit.optimization import QuadraticProgram
+        >>> op = QuadraticProgram()
         >>> indices = op.linear_constraints.add(
         ...     senses=["E", "G", "L", "R"],
         ...     names=[str(i) for i in range(4)])
@@ -612,8 +612,8 @@ class LinearConstraintInterface(BaseInterface):
           indices the members of s.  Equivalent to
           [linear_constraints.get_range_values(i) for i in s]
 
-        >>> from qiskit.optimization import OptimizationProblem
-        >>> op = OptimizationProblem()
+        >>> from qiskit.optimization import QuadraticProgram
+        >>> op = QuadraticProgram()
         >>> indices = op.linear_constraints.add(\
                 range_values = [1.5 * i for i in range(10)],\
                 senses = ["R"] * 10,\
@@ -655,8 +655,8 @@ class LinearConstraintInterface(BaseInterface):
         linear_constraints.get_coefficients(sequence_of_pairs)
           returns a list of coefficients.
 
-        >>> from qiskit.optimization import OptimizationProblem
-        >>> op = OptimizationProblem()
+        >>> from qiskit.optimization import QuadraticProgram
+        >>> op = QuadraticProgram()
         >>> indices = op.variables.add(names = ["x0", "x1"])
         >>> indices = op.linear_constraints.add(\
                 names = ["c0", "c1"],\
@@ -708,8 +708,8 @@ class LinearConstraintInterface(BaseInterface):
           of s.  Equivalent to
           [linear_constraints.get_rows(i) for i in s]
 
-        >>> from qiskit.optimization import OptimizationProblem
-        >>> op = OptimizationProblem()
+        >>> from qiskit.optimization import QuadraticProgram
+        >>> op = QuadraticProgram()
         >>> indices = op.variables.add(names = ["x1", "x2", "x3"])
         >>> indices = op.linear_constraints.add(\
                 names = ["c0", "c1", "c2", "c3"],\
@@ -744,8 +744,8 @@ class LinearConstraintInterface(BaseInterface):
 
         Example usage:
 
-        >>> from qiskit.optimization import OptimizationProblem
-        >>> op = OptimizationProblem()
+        >>> from qiskit.optimization import QuadraticProgram
+        >>> op = QuadraticProgram()
         >>> indices = op.variables.add(names = ["x1", "x2", "x3"])
         >>> indices = op.linear_constraints.add(names = ["c0", "c1", "c2", "c3"],\
                                     lin_expr = [SparsePair(ind = ["x1", "x3"], val = [1.0, -1.0]),\
@@ -778,8 +778,8 @@ class LinearConstraintInterface(BaseInterface):
           the linear constraints with indices the members of s.
           Equivalent to [linear_constraints.get_names(i) for i in s]
 
-        >>> from qiskit.optimization import OptimizationProblem
-        >>> op = OptimizationProblem()
+        >>> from qiskit.optimization import QuadraticProgram
+        >>> op = QuadraticProgram()
         >>> indices = op.linear_constraints.add(names = ["c" + str(i) for i in range(10)])
         >>> op.linear_constraints.get_num()
         10

--- a/qiskit/optimization/problems/objective.py
+++ b/qiskit/optimization/problems/objective.py
@@ -53,8 +53,8 @@ class ObjSense:
 
         Example usage:
 
-        >>> from qiskit.optimization import OptimizationProblem
-        >>> op = OptimizationProblem()
+        >>> from qiskit.optimization import QuadraticProgram
+        >>> op = QuadraticProgram()
         >>> op.objective.sense.minimize
         1
         >>> op.objective.sense[1]
@@ -76,7 +76,7 @@ class ObjectiveInterface(BaseInterface):
         """Creates a new ObjectiveInterface.
 
         The objective function interface is exposed by the top-level
-        `OptimizationProblem` class as `OptimizationProblem.objective`.
+        `QuadraticProgram` class as `QuadraticProgram.objective`.
         This constructor is not meant to be used externally.
         """
         if not _HAS_CPLEX:
@@ -105,8 +105,8 @@ class ObjectiveInterface(BaseInterface):
           above.  Changes the coefficients for the specified
           variables to the given values.
 
-        >>> from qiskit.optimization import OptimizationProblem
-        >>> op = OptimizationProblem()
+        >>> from qiskit.optimization import QuadraticProgram
+        >>> op = QuadraticProgram()
         >>> indices = op.variables.add(names = [str(i) for i in range(4)])
         >>> op.objective.get_linear()
         [0.0, 0.0, 0.0, 0.0]
@@ -151,8 +151,8 @@ class ObjectiveInterface(BaseInterface):
           quadratic objective function, use the method
           set_quadratic_coefficients.
 
-        >>> from qiskit.optimization import OptimizationProblem
-        >>> op = OptimizationProblem()
+        >>> from qiskit.optimization import QuadraticProgram
+        >>> op = QuadraticProgram()
         >>> indices = op.variables.add(names = [str(i) for i in range(3)])
         >>> op.objective.set_quadratic([SparsePair(ind = [0, 1, 2], val = [1.0, -2.0, 0.5]),\
                                        SparsePair(ind = [0, 1], val = [-2.0, -1.0]),\
@@ -224,8 +224,8 @@ class ObjectiveInterface(BaseInterface):
           can be time consuming. Instead, use the method set_quadratic to set
           the quadratic part of the objective efficiently.
 
-        >>> from qiskit.optimization import OptimizationProblem
-        >>> op = OptimizationProblem()
+        >>> from qiskit.optimization import QuadraticProgram
+        >>> op = QuadraticProgram()
         >>> indices = op.variables.add(names = [str(i) for i in range(3)])
         >>> op.objective.set_quadratic_coefficients(0, 1, 1.0)
         >>> op.objective.get_quadratic()
@@ -268,8 +268,8 @@ class ObjectiveInterface(BaseInterface):
         The argument to this method must be either
         objective.sense.minimize or objective.sense.maximize.
 
-        >>> from qiskit.optimization import OptimizationProblem
-        >>> op = OptimizationProblem()
+        >>> from qiskit.optimization import QuadraticProgram
+        >>> op = QuadraticProgram()
         >>> op.objective.sense[op.objective.get_sense()]
         'minimize'
         >>> op.objective.set_sense(op.objective.sense.maximize)
@@ -291,8 +291,8 @@ class ObjectiveInterface(BaseInterface):
 
         Example usage:
 
-        >>> from qiskit.optimization import OptimizationProblem
-        >>> op = OptimizationProblem()
+        >>> from qiskit.optimization import QuadraticProgram
+        >>> op = QuadraticProgram()
         >>> op.objective.set_name("cost")
         >>> op.objective.get_name()
         'cost'
@@ -319,8 +319,8 @@ class ObjectiveInterface(BaseInterface):
           indices the members of s.  Equivalent to
           [objective.get_linear(i) for i in s]
 
-        >>> from qiskit.optimization import OptimizationProblem
-        >>> op = OptimizationProblem()
+        >>> from qiskit.optimization import QuadraticProgram
+        >>> op = QuadraticProgram()
         >>> indices = op.variables.add(obj = [1.5 * i for i in range(10)],\
                             names = [str(i) for i in range(10)])
         >>> op.variables.get_num()
@@ -344,8 +344,8 @@ class ObjectiveInterface(BaseInterface):
 
         Example usage:
 
-        >>> from qiskit.optimization import OptimizationProblem
-        >>> op = OptimizationProblem()
+        >>> from qiskit.optimization import QuadraticProgram
+        >>> op = QuadraticProgram()
         >>> op.variables.add(names=['x', 'y'])
         >>> op.objective.set_linear([('x', 1), ('y', 2)])
         >>> print(op.objective.get_linear_dict())
@@ -374,8 +374,8 @@ class ObjectiveInterface(BaseInterface):
           with the variables with indices the members of s.
           Equivalent to [objective.get_quadratic(i) for i in s]
 
-        >>> from qiskit.optimization import OptimizationProblem
-        >>> op = OptimizationProblem()
+        >>> from qiskit.optimization import QuadraticProgram
+        >>> op = QuadraticProgram()
         >>> indices = op.variables.add(names = [str(i) for i in range(10)])
         >>> op.variables.get_num()
         10
@@ -410,8 +410,8 @@ class ObjectiveInterface(BaseInterface):
 
         Example usage:
 
-        >>> from qiskit.optimization import OptimizationProblem
-        >>> op = OptimizationProblem()
+        >>> from qiskit.optimization import QuadraticProgram
+        >>> op = QuadraticProgram()
         >>> op.variables.add(names=['x', 'y'])
         >>> op.objective.set_quadratic_coefficients([('x', 'x', 1), ('x', 'y', 2)])
         >>> print(op.objective.get_quadratic_dict())
@@ -429,8 +429,8 @@ class ObjectiveInterface(BaseInterface):
           query multiple coefficients where sequence is a list or tuple of pairs (v1, v2) as
           described above.
 
-        >>> from qiskit.optimization import OptimizationProblem
-        >>> op = OptimizationProblem()
+        >>> from qiskit.optimization import QuadraticProgram
+        >>> op = QuadraticProgram()
         >>> indices = op.variables.add(names = [str(i) for i in range(3)])
         >>> op.objective.set_quadratic_coefficients(0, 1, 1.0)
         >>> op.objective.get_quadratic_coefficients("1", 0)
@@ -467,8 +467,8 @@ class ObjectiveInterface(BaseInterface):
 
         Example usage:
 
-        >>> from qiskit.optimization import OptimizationProblem
-        >>> op = OptimizationProblem()
+        >>> from qiskit.optimization import QuadraticProgram
+        >>> op = QuadraticProgram()
         >>> op.objective.sense[op.objective.get_sense()]
         'minimize'
         >>> op.objective.set_sense(op.objective.sense.maximize)
@@ -485,8 +485,8 @@ class ObjectiveInterface(BaseInterface):
 
         Example usage:
 
-        >>> from qiskit.optimization import OptimizationProblem
-        >>> op = OptimizationProblem()
+        >>> from qiskit.optimization import QuadraticProgram
+        >>> op = QuadraticProgram()
         >>> op.objective.set_name("cost")
         >>> op.objective.get_name()
         'cost'
@@ -498,8 +498,8 @@ class ObjectiveInterface(BaseInterface):
 
         Example usage:
 
-        >>> from qiskit.optimization import OptimizationProblem
-        >>> op = OptimizationProblem()
+        >>> from qiskit.optimization import QuadraticProgram
+        >>> op = QuadraticProgram()
         >>> indices = op.variables.add(names = [str(i) for i in range(3)])
         >>> op.objective.set_quadratic_coefficients(0, 1, 1.0)
         >>> op.objective.get_num_quadratic_variables()
@@ -522,8 +522,8 @@ class ObjectiveInterface(BaseInterface):
 
         Example usage:
 
-        >>> from qiskit.optimization import OptimizationProblem
-        >>> op = OptimizationProblem()
+        >>> from qiskit.optimization import QuadraticProgram
+        >>> op = QuadraticProgram()
         >>> indices = op.variables.add(names = [str(i) for i in range(3)])
         >>> op.objective.set_quadratic_coefficients(0, 1, 1.0)
         >>> op.objective.get_num_quadratic_nonzeros()
@@ -542,8 +542,8 @@ class ObjectiveInterface(BaseInterface):
 
         Example usage:
 
-        >>> from qiskit.optimization import OptimizationProblem
-        >>> op = OptimizationProblem()
+        >>> from qiskit.optimization import QuadraticProgram
+        >>> op = QuadraticProgram()
         >>> offset = op.objective.get_offset()
         >>> abs(offset - 0.0) < 1e-6
         True
@@ -555,8 +555,8 @@ class ObjectiveInterface(BaseInterface):
 
         Example usage:
 
-        >>> from qiskit.optimization import OptimizationProblem
-        >>> op = OptimizationProblem()
+        >>> from qiskit.optimization import QuadraticProgram
+        >>> op = QuadraticProgram()
         >>> op.objective.set_offset(3.14)
         >>> offset = op.objective.get_offset()
         >>> abs(offset - 3.14) < 1e-6

--- a/qiskit/optimization/problems/problem_type.py
+++ b/qiskit/optimization/problems/problem_type.py
@@ -33,7 +33,7 @@ CPXPROB_NODEQCP = 12
 
 class ProblemType:
     """
-    Types of problems the OptimizationProblem class can encapsulate.
+    Types of problems the QuadraticProgram class can encapsulate.
     These types are compatible with those of IBM ILOG CPLEX.
     For explanations of the problem types, see those topics in the
     CPLEX User's Manual in the topic titled Continuous Optimization
@@ -64,8 +64,8 @@ class ProblemType:
 
         Example usage:
 
-        >>> from qiskit.optimization import OptimizationProblem
-        >>> op = OptimizationProblem()
+        >>> from qiskit.optimization import QuadraticProgram
+        >>> op = QuadraticProgram()
         >>> op.problem_type.LP
         0
         >>> op.problem_type[0]

--- a/qiskit/optimization/problems/quadratic_constraint.py
+++ b/qiskit/optimization/problems/quadratic_constraint.py
@@ -42,7 +42,7 @@ class QuadraticConstraintInterface(BaseInterface):
         """Creates a new QuadraticConstraintInterface.
 
         The quadratic constraints interface is exposed by the top-level
-        `OptimizationProblem` class as `OptimizationProblem.quadratic_constraints`.
+        `QuadraticProgram` class as `QuadraticProgram.quadratic_constraints`.
         This constructor is not meant to be used externally.
         """
         if not _HAS_CPLEX:
@@ -62,8 +62,8 @@ class QuadraticConstraintInterface(BaseInterface):
 
         Example usage:
 
-        >>> from qiskit.optimization import OptimizationProblem
-        >>> op = OptimizationProblem()
+        >>> from qiskit.optimization import QuadraticProgram
+        >>> op = QuadraticProgram()
         >>> indices = op.variables.add(names = ['x','y'])
         >>> l = SparsePair(ind = ['x'], val = [1.0])
         >>> q = SparseTriple(ind1 = ['x'], ind2 = ['y'], val = [1.0])
@@ -114,8 +114,8 @@ class QuadraticConstraintInterface(BaseInterface):
         Raises:
             QiskitOptimizationError: if arguments are not valid.
 
-        >>> from qiskit.optimization import OptimizationProblem
-        >>> op = OptimizationProblem()
+        >>> from qiskit.optimization import QuadraticProgram
+        >>> op = QuadraticProgram()
         >>> indices = op.variables.add(names = ['x','y'])
         >>> l = SparsePair(ind = ['x'], val = [1.0])
         >>> q = SparseTriple(ind1 = ['x'], ind2 = ['y'], val = [1.0])
@@ -219,8 +219,8 @@ class QuadraticConstraintInterface(BaseInterface):
 
         Example usage:
 
-        >>> from qiskit.optimization import OptimizationProblem
-        >>> op = OptimizationProblem()
+        >>> from qiskit.optimization import QuadraticProgram
+        >>> op = QuadraticProgram()
         >>> indices = op.variables.add(names=['x', 'y'])
         >>> l = SparsePair(ind=['x'], val=[1.0])
         >>> q = SparseTriple(ind1=['x'], ind2=['y'], val=[1.0])
@@ -291,8 +291,8 @@ class QuadraticConstraintInterface(BaseInterface):
           end. Equivalent to
           quadratic_constraints.get_rhs(range(begin, end + 1)).
 
-        >>> from qiskit.optimization import OptimizationProblem
-        >>> op = OptimizationProblem()
+        >>> from qiskit.optimization import QuadraticProgram
+        >>> op = QuadraticProgram()
         >>> indices = op.variables.add(names = [str(i) for i in range(10)])
         >>> [op.quadratic_constraints.add(rhs=1.5 * i, name=str(i))
         ...  for i in range(10)]
@@ -343,8 +343,8 @@ class QuadraticConstraintInterface(BaseInterface):
           end. Equivalent to
           quadratic_constraints.get_senses(range(begin, end + 1)).
 
-        >>> from qiskit.optimization import OptimizationProblem
-        >>> op = OptimizationProblem()
+        >>> from qiskit.optimization import QuadraticProgram
+        >>> op = QuadraticProgram()
         >>> indices = op.variables.add(names = ["x0"])
         >>> [op.quadratic_constraints.add(name=str(i), sense=j)
         ...  for i, j in enumerate("GGLL")]
@@ -396,8 +396,8 @@ class QuadraticConstraintInterface(BaseInterface):
           inclusive of end. Equivalent to
           quadratic_constraints.get_linear_num_nonzeros(range(begin, end + 1)).
 
-        >>> from qiskit.optimization import OptimizationProblem
-        >>> op = OptimizationProblem()
+        >>> from qiskit.optimization import QuadraticProgram
+        >>> op = QuadraticProgram()
         >>> indices = op.variables.add(names = [str(i) for i in range(11)], types = "B" * 11)
         >>> [op.quadratic_constraints.add(
         ...      name = str(i),
@@ -454,8 +454,8 @@ class QuadraticConstraintInterface(BaseInterface):
 
         Examples:
 
-        >>> from qiskit.optimization import OptimizationProblem
-        >>> op = OptimizationProblem()
+        >>> from qiskit.optimization import QuadraticProgram
+        >>> op = QuadraticProgram()
         >>> indices = op.variables.add(
         ...     names=[str(i) for i in range(4)],
         ...     types="B" * 4
@@ -518,8 +518,8 @@ class QuadraticConstraintInterface(BaseInterface):
           inclusive of end. Equivalent to
           quadratic_constraints.get_quad_num_nonzeros(range(begin, end + 1)).
 
-        >>> from qiskit.optimization import OptimizationProblem
-        >>> op = OptimizationProblem()
+        >>> from qiskit.optimization import QuadraticProgram
+        >>> op = QuadraticProgram()
         >>> indices = op.variables.add(names = [str(i) for i in range(11)])
         >>> [op.quadratic_constraints.add(
         ...      name = str(i),
@@ -571,8 +571,8 @@ class QuadraticConstraintInterface(BaseInterface):
           inclusive of end. Equivalent to
           quadratic_constraints.get_quadratic_components(range(begin, end + 1)).
 
-        >>> from qiskit.optimization import OptimizationProblem
-        >>> op = OptimizationProblem()
+        >>> from qiskit.optimization import QuadraticProgram
+        >>> op = QuadraticProgram()
         >>> indices = op.variables.add(
         ...     names=[str(i) for i in range(4)]
         ... )
@@ -639,8 +639,8 @@ class QuadraticConstraintInterface(BaseInterface):
           begin and end, inclusive of end. Equivalent to
           quadratic_constraints.get_names(range(begin, end + 1)).
 
-        >>> from qiskit.optimization.problems import OptimizationProblem
-        >>> op = OptimizationProblem()
+        >>> from qiskit.optimization.problems import QuadraticProgram
+        >>> op = QuadraticProgram()
         >>> indices = op.variables.add(names = [str(i) for i in range(11)])
         >>> [op.quadratic_constraints.add(
         ...      name = "q" + str(i),

--- a/qiskit/optimization/problems/quadratic_program.py
+++ b/qiskit/optimization/problems/quadratic_program.py
@@ -41,18 +41,18 @@ except ImportError:
     logger.info('CPLEX is not installed.')
 
 
-class OptimizationProblem:
+class QuadraticProgram:
     """A class encapsulating an optimization problem, modeled after Python CPLEX API.
 
-    An instance of the OptimizationProblem class provides methods for creating,
+    An instance of the QuadraticProgram class provides methods for creating,
     modifying, and querying an optimization problem, solving it, and
     querying aspects of the solution.
     """
 
     def __init__(self, file_name: Optional[str] = None):
-        """Constructor of the OptimizationProblem class.
+        """Constructor of the QuadraticProgram class.
 
-        The OptimizationProblem constructor accepts four types of argument lists.
+        The QuadraticProgram constructor accepts four types of argument lists.
 
         Args:
             file_name: read a model from a file.
@@ -63,19 +63,19 @@ class OptimizationProblem:
 
         Examples:
 
-        >>> from qiskit.optimization import OptimizationProblem
-        >>> op = OptimizationProblem()
+        >>> from qiskit.optimization import QuadraticProgram
+        >>> op = QuadraticProgram()
         op is a new problem with no data
 
-        >>> from qiskit.optimization import OptimizationProblem
-        >>> op = OptimizationProblem("filename")
+        >>> from qiskit.optimization import QuadraticProgram
+        >>> op = QuadraticProgram("filename")
         op is a new problem containing the data in filename.  If
         filename does not exist, an exception is raised.
 
-        The OptimizationProblem object is a context manager and can be used, like so:
+        The QuadraticProgram object is a context manager and can be used, like so:
 
-        >>> from qiskit.optimization import OptimizationProblem
-        >>> with OptimizationProblem() as op:
+        >>> from qiskit.optimization import QuadraticProgram
+        >>> with QuadraticProgram() as op:
         >>>     # do stuff
         >>>     op.solve()
 
@@ -226,7 +226,7 @@ class OptimizationProblem:
         return op
 
     def end(self):
-        """Releases the OptimizationProblem object."""
+        """Releases the QuadraticProgram object."""
         self._name = ''
         self.variables = VariablesInterface()
         varindex = self.variables.get_indices
@@ -236,7 +236,7 @@ class OptimizationProblem:
         self.solution = SolutionInterface()
         self._problem_type = None
 
-    def __enter__(self) -> 'OptimizationProblem':
+    def __enter__(self) -> 'QuadraticProgram':
         """To implement a ContextManager, as in Cplex."""
         return self
 
@@ -251,8 +251,8 @@ class OptimizationProblem:
         The first argument is a string specifying the filename from
         which the problem will be read.
 
-        >>> from qiskit.optimization import OptimizationProblem
-        >>> op = OptimizationProblem()
+        >>> from qiskit.optimization import QuadraticProgram
+        >>> op = QuadraticProgram()
         >>> op.read("lpex.mps")
         """
         cplex = Cplex()
@@ -267,8 +267,8 @@ class OptimizationProblem:
 
         Example usage:
 
-        >>> from qiskit.optimization import OptimizationProblem
-        >>> op = OptimizationProblem()
+        >>> from qiskit.optimization import QuadraticProgram
+        >>> op = QuadraticProgram()
         >>> indices = op.variables.add(names=['x1', 'x2', 'x3'])
         >>> op.write("example.lp")
         """
@@ -279,7 +279,7 @@ class OptimizationProblem:
         """Writes a problem to a file-like object in the given file format.
 
         The filetype argument can be any of "sav" (a binary format), "lp"
-        (the default), "mps", "rew", "rlp", or "alp" (see `OptimizationProblem.write`
+        (the default), "mps", "rew", "rlp", or "alp" (see `QuadraticProgram.write`
         for an explanation of these).
 
         If comptype is "bz2" (for BZip2) or "gz" (for GNU Zip), a
@@ -290,8 +290,8 @@ class OptimizationProblem:
 
         Example usage:
 
-        >>> from qiskit.optimization import OptimizationProblem
-        >>> op = OptimizationProblem()
+        >>> from qiskit.optimization import QuadraticProgram
+        >>> op = QuadraticProgram()
         >>> indices = op.variables.add(names=['x1', 'x2', 'x3'])
         >>> class NoOpStream(object):
         ...     def __init__(self):
@@ -316,8 +316,8 @@ class OptimizationProblem:
     def write_as_string(self, filetype: str = 'LP', comptype: str = '') -> str:
         """Writes a problem as a string in the given file format.
 
-        >>> from qiskit.optimization import OptimizationProblem
-        >>> op = OptimizationProblem()
+        >>> from qiskit.optimization import QuadraticProgram
+        >>> op = QuadraticProgram()
         >>> indices = op.variables.add(names=['x1', 'x2', 'x3'])
         >>> lp_str = op.write_as_string("lp")
         >>> len(lp_str) > 0
@@ -331,8 +331,8 @@ class OptimizationProblem:
 
         The return value is an attribute of self.problem_type.
 
-        >>> from qiskit.optimization import OptimizationProblem
-        >>> op = OptimizationProblem()
+        >>> from qiskit.optimization import QuadraticProgram
+        >>> op = QuadraticProgram()
         >>> op.read("lpex.mps")
         >>> op.get_problem_type()
         0
@@ -374,7 +374,7 @@ class OptimizationProblem:
         """Prints out a message to ask users to use `OptimizationAlgorithm`.
         Users need to apply one of `OptimiztionAlgorithm`s instead of this method.
         """
-        logger.warning('`OptimizationProblem.solve` is intentionally empty.'
+        logger.warning('`QuadraticProgram.solve` is intentionally empty.'
                        'You can solve it by applying `OptimizationAlgorithm.solve`.')
 
     def set_problem_name(self, name: str):
@@ -387,7 +387,7 @@ class OptimizationProblem:
 
     def substitute_variables(self, constants: Optional['SparsePair'] = None,
                              variables: Optional['SparseTriple'] = None) \
-            -> Tuple['OptimizationProblem', 'SubstitutionStatus']:
+            -> Tuple['QuadraticProgram', 'SubstitutionStatus']:
         """Substitutes variables with constants or other variables.
 
         Args:
@@ -412,9 +412,9 @@ class OptimizationProblem:
 
         Example usage:
 
-        >>> from qiskit.optimization import OptimizationProblem
+        >>> from qiskit.optimization import QuadraticProgram
         >>> from cplex import SparsePair, SparseTriple
-        >>> op = OptimizationProblem()
+        >>> op = QuadraticProgram()
         >>> op.variables.add(names=['x', 'y'], types='I'*2, lb=[-1]*2, ub=[2]*2)
         >>> op.objective.set_sense(op.objective.sense.minimize)
         >>> op.objective.set_linear([('x', 1), ('y', 2)])
@@ -474,7 +474,7 @@ class OptimizationProblem:
 
 
 class SubstitutionStatus(Enum):
-    """Status of `OptimizationProblem.substitute_variables`"""
+    """Status of `QuadraticProgram.substitute_variables`"""
     success = 1
     infeasible = 2
 
@@ -486,14 +486,14 @@ class SubstituteVariables:
     CONST = -1
 
     def __init__(self):
-        self._src: OptimizationProblem = None
-        self._dst: OptimizationProblem = None
+        self._src: QuadraticProgram = None
+        self._dst: QuadraticProgram = None
         self._subs = {}
 
-    def substitute_variables(self, src: OptimizationProblem,
+    def substitute_variables(self, src: QuadraticProgram,
                              constants: Optional['SparsePair'] = None,
                              variables: Optional['SparseTriple'] = None) \
-            -> Tuple[OptimizationProblem, SubstitutionStatus]:
+            -> Tuple[QuadraticProgram, SubstitutionStatus]:
         """Substitutes variables with constants or other variables.
 
         Args:
@@ -519,7 +519,7 @@ class SubstituteVariables:
         """
 
         self._src = src
-        self._dst = OptimizationProblem()
+        self._dst = QuadraticProgram()
         self._dst.set_problem_name(src.get_problem_name())
         # do not set problem type, then it detects its type automatically
 

--- a/qiskit/optimization/problems/variables.py
+++ b/qiskit/optimization/problems/variables.py
@@ -53,8 +53,8 @@ class VarTypes:
 
         Example usage:
 
-        >>> from qiskit.optimization.problems import OptimizationProblem
-        >>> op = OptimizationProblem()
+        >>> from qiskit.optimization.problems import QuadraticProgram
+        >>> op = QuadraticProgram()
         >>> op.variables.type.binary
         'B'
         >>> op.variables.type['B']
@@ -78,8 +78,8 @@ class VariablesInterface(BaseInterface):
 
     Example usage:
 
-    >>> from qiskit.optimization import OptimizationProblem
-    >>> op = OptimizationProblem()
+    >>> from qiskit.optimization import QuadraticProgram
+    >>> op = QuadraticProgram()
     >>> indices = op.variables.add(names = ["x0", "x1", "x2"])
     >>> # default values for lower_bounds are 0.0
     >>> op.variables.get_lower_bounds()
@@ -106,8 +106,8 @@ class VariablesInterface(BaseInterface):
     def __init__(self):
         """Creates a new VariablesInterface.
 
-        The variables interface is exposed by the top-level `OptimizationProblem` class
-        as `OptimizationProblem.variables`.  This constructor is not meant to be used
+        The variables interface is exposed by the top-level `QuadraticProgram` class
+        as `QuadraticProgram.variables`.  This constructor is not meant to be used
         externally.
         """
         super(VariablesInterface, self).__init__()
@@ -124,8 +124,8 @@ class VariablesInterface(BaseInterface):
 
         Example usage:
 
-        >>> from qiskit.optimization import OptimizationProblem
-        >>> op = OptimizationProblem()
+        >>> from qiskit.optimization import QuadraticProgram
+        >>> op = QuadraticProgram()
         >>> t = op.variables.type
         >>> indices = op.variables.add(types = [t.continuous, t.binary, t.integer])
         >>> op.variables.get_num()
@@ -138,8 +138,8 @@ class VariablesInterface(BaseInterface):
 
         Example usage:
 
-        >>> from qiskit.optimization import OptimizationProblem
-        >>> op = OptimizationProblem()
+        >>> from qiskit.optimization import QuadraticProgram
+        >>> op = QuadraticProgram()
         >>> t = op.variables.type
         >>> indices = op.variables.add(types = [t.continuous, t.binary, t.integer])
         >>> op.variables.get_num_continuous()
@@ -152,8 +152,8 @@ class VariablesInterface(BaseInterface):
 
         Example usage:
 
-        >>> from qiskit.optimization import OptimizationProblem
-        >>> op = OptimizationProblem()
+        >>> from qiskit.optimization import QuadraticProgram
+        >>> op = QuadraticProgram()
         >>> t = op.variables.type
         >>> indices = op.variables.add(types = [t.continuous, t.binary, t.integer])
         >>> op.variables.get_num_integer()
@@ -166,8 +166,8 @@ class VariablesInterface(BaseInterface):
 
         Example usage:
 
-        >>> from qiskit.optimization import OptimizationProblem
-        >>> op = OptimizationProblem()
+        >>> from qiskit.optimization import QuadraticProgram
+        >>> op = QuadraticProgram()
         >>> t = op.variables.type
         >>> indices = op.variables.add(types = [t.semi_continuous, t.binary, t.integer])
         >>> op.variables.get_num_binary()
@@ -180,8 +180,8 @@ class VariablesInterface(BaseInterface):
 
         Example usage:
 
-        >>> from qiskit.optimization import OptimizationProblem
-        >>> op = OptimizationProblem()
+        >>> from qiskit.optimization import QuadraticProgram
+        >>> op = QuadraticProgram()
         >>> t = op.variables.type
         >>> indices = op.variables.add(types = [t.semi_continuous, t.semi_integer, t.semi_integer])
         >>> op.variables.get_num_semicontinuous()
@@ -194,8 +194,8 @@ class VariablesInterface(BaseInterface):
 
         Example usage:
 
-        >>> from qiskit.optimization import OptimizationProblem
-        >>> op = OptimizationProblem()
+        >>> from qiskit.optimization import QuadraticProgram
+        >>> op = QuadraticProgram()
         >>> t = op.variables.type
         >>> indices = op.variables.add(types = [t.semi_continuous, t.semi_integer, t.semi_integer])
         >>> op.variables.get_num_semiinteger()
@@ -242,9 +242,9 @@ class VariablesInterface(BaseInterface):
 
         Example usage:
 
-        >>> from qiskit.optimization import OptimizationProblem
+        >>> from qiskit.optimization import QuadraticProgram
         >>> from cplex import SparsePair, infinity
-        >>> op = OptimizationProblem()
+        >>> op = QuadraticProgram()
         >>> indices = op.linear_constraints.add(names = ["c0", "c1", "c2"])
         >>> indices = op.variables.add(obj = [1.0, 2.0, 3.0],\
                                       types = [op.variables.type.integer] * 3)
@@ -325,8 +325,8 @@ class VariablesInterface(BaseInterface):
 
         Example usage:
 
-        >>> from qiskit.optimization import OptimizationProblem
-        >>> op = OptimizationProblem()
+        >>> from qiskit.optimization import QuadraticProgram
+        >>> op = QuadraticProgram()
         >>> indices = op.variables.add(names=[str(i) for i in range(10)])
         >>> op.variables.get_num()
         10
@@ -384,8 +384,8 @@ class VariablesInterface(BaseInterface):
           the corresponding values.  Equivalent to
           [variables.set_lower_bounds(pair[0], pair[1]) for pair in seq_of_pairs].
 
-        >>> from qiskit.optimization import OptimizationProblem
-        >>> op = OptimizationProblem()
+        >>> from qiskit.optimization import QuadraticProgram
+        >>> op = QuadraticProgram()
         >>> indices = op.variables.add(names = ["x0", "x1", "x2"])
         >>> op.variables.set_lower_bounds(0, 1.0)
         >>> op.variables.get_lower_bounds()
@@ -418,8 +418,8 @@ class VariablesInterface(BaseInterface):
           the corresponding values.  Equivalent to
           [variables.set_upper_bounds(pair[0], pair[1]) for pair in seq_of_pairs].
 
-        >>> from qiskit.optimization import OptimizationProblem
-        >>> op = OptimizationProblem()
+        >>> from qiskit.optimization import QuadraticProgram
+        >>> op = QuadraticProgram()
         >>> indices = op.variables.add(names = ["x0", "x1", "x2"])
         >>> op.variables.set_upper_bounds(0, 1.0)
         >>> op.variables.set_upper_bounds([("x1", 10.0), (2, 3.0)])
@@ -449,8 +449,8 @@ class VariablesInterface(BaseInterface):
           corresponding strings.  Equivalent to
           [variables.set_names(pair[0], pair[1]) for pair in seq_of_pairs].
 
-        >>> from qiskit.optimization import OptimizationProblem
-        >>> op = OptimizationProblem()
+        >>> from qiskit.optimization import QuadraticProgram
+        >>> op = QuadraticProgram()
         >>> t = op.variables.type
         >>> indices = op.variables.add(types = [t.continuous, t.binary, t.integer])
         >>> op.variables.set_names(0, "first")
@@ -486,8 +486,8 @@ class VariablesInterface(BaseInterface):
           If the types are set, the problem will be treated as a MIP,
           even if all variable types are continuous.
 
-        >>> from qiskit.optimization import OptimizationProblem
-        >>> op = OptimizationProblem()
+        >>> from qiskit.optimization import QuadraticProgram
+        >>> op = QuadraticProgram()
         >>> indices = op.variables.add(names = [str(i) for i in range(5)])
         >>> op.variables.set_types(0, op.variables.type.continuous)
         >>> op.variables.set_types([("1", op.variables.type.integer),\
@@ -526,8 +526,8 @@ class VariablesInterface(BaseInterface):
           of s.  Equivalent to
           [variables.get_lower_bounds(i) for i in s]
 
-        >>> from qiskit.optimization import OptimizationProblem
-        >>> op = OptimizationProblem()
+        >>> from qiskit.optimization import QuadraticProgram
+        >>> op = QuadraticProgram()
         >>> indices = op.variables.add(lb = [1.5 * i for i in range(10)],\
                                       names = [str(i) for i in range(10)])
         >>> op.variables.get_num()
@@ -574,8 +574,8 @@ class VariablesInterface(BaseInterface):
           begin and end, inclusive of end. Equivalent to
           variables.get_upper_bounds(range(begin, end + 1)).
 
-        >>> from qiskit.optimization import OptimizationProblem
-        >>> op = OptimizationProblem()
+        >>> from qiskit.optimization import QuadraticProgram
+        >>> op = QuadraticProgram()
         >>> indices = op.variables.add(ub = [(1.5 * i) + 1.0 for i in range(10)],\
                                       names = [str(i) for i in range(10)])
         >>> op.variables.get_num()
@@ -614,8 +614,8 @@ class VariablesInterface(BaseInterface):
           names of the variables with indices the members of s.
           Equivalent to [variables.get_names(i) for i in s]
 
-        >>> from qiskit.optimization import OptimizationProblem
-        >>> op = OptimizationProblem()
+        >>> from qiskit.optimization import QuadraticProgram
+        >>> op = QuadraticProgram()
         >>> indices = op.variables.add(names = ['x' + str(i) for i in range(10)])
         >>> op.variables.get_num()
         10
@@ -654,8 +654,8 @@ class VariablesInterface(BaseInterface):
           the types of the variables with indices the members of s.
           Equivalent to [variables.get_types(i) for i in s]
 
-        >>> from qiskit.optimization import OptimizationProblem
-        >>> op = OptimizationProblem()
+        >>> from qiskit.optimization import QuadraticProgram
+        >>> op = QuadraticProgram()
         >>> t = op.variables.type
         >>> indices = op.variables.add(names = [str(i) for i in range(5)],\
                                       types = [t.continuous, t.integer,\

--- a/qiskit/optimization/utils/base.py
+++ b/qiskit/optimization/utils/base.py
@@ -53,8 +53,8 @@ class BaseInterface(ABC):
 
         Example usage:
 
-        >>> from qiskit.optimization import OptimizationProblem
-        >>> op = OptimizationProblem()
+        >>> from qiskit.optimization import QuadraticProgram
+        >>> op = QuadraticProgram()
         >>> indices = op.variables.add(names=["a", "b"])
         >>> op.variables.get_indices("a")
         0

--- a/test/optimization/test_admm.py
+++ b/test/optimization/test_admm.py
@@ -24,7 +24,7 @@ from qiskit.aqua.algorithms import NumPyMinimumEigensolver
 from qiskit.optimization.algorithms import CplexOptimizer, MinimumEigenOptimizer
 from qiskit.optimization.algorithms.admm_optimizer import ADMMOptimizer, ADMMParameters, \
     ADMMOptimizerResult, ADMMState
-from qiskit.optimization.problems import OptimizationProblem
+from qiskit.optimization.problems import QuadraticProgram
 
 
 class TestADMMOptimizer(QiskitOptimizationTestCase):
@@ -37,7 +37,7 @@ class TestADMMOptimizer(QiskitOptimizationTestCase):
             c = mdl.continuous_var(lb=0, ub=10, name='c')
             x = mdl.binary_var(name='x')
             mdl.maximize(c + x * x)
-            op = OptimizationProblem()
+            op = QuadraticProgram()
             op.from_docplex(mdl)
             self.assertIsNotNone(op)
 
@@ -82,7 +82,7 @@ class TestADMMOptimizer(QiskitOptimizationTestCase):
             mdl.add_constraint(v + w + t >= 1, "cons2")
             mdl.add_constraint(v + w == 1, "cons3")
 
-            op = OptimizationProblem()
+            op = QuadraticProgram()
             op.from_docplex(mdl)
 
             qubo_optimizer = CplexOptimizer()
@@ -127,7 +127,7 @@ class TestADMMOptimizer(QiskitOptimizationTestCase):
             mdl.add_constraint(v + w + t >= 1, "cons2")
             mdl.add_constraint(v + w == 1, "cons3")
 
-            op = OptimizationProblem()
+            op = QuadraticProgram()
             op.from_docplex(mdl)
 
             qubo_optimizer = CplexOptimizer()

--- a/test/optimization/test_cobyla_optimizer.py
+++ b/test/optimization/test_cobyla_optimizer.py
@@ -20,7 +20,7 @@ import logging
 from ddt import ddt, data
 
 from qiskit.optimization.algorithms import CobylaOptimizer
-from qiskit.optimization.problems import OptimizationProblem
+from qiskit.optimization.problems import QuadraticProgram
 
 logger = logging.getLogger(__name__)
 
@@ -54,7 +54,7 @@ class TestCobylaOptimizer(QiskitOptimizationTestCase):
         filename, fval = config
 
         # load optimization problem
-        problem = OptimizationProblem()
+        problem = QuadraticProgram()
         problem.read(self.resource_path + filename)
 
         # solve problem with cobyla
@@ -66,7 +66,7 @@ class TestCobylaOptimizer(QiskitOptimizationTestCase):
     def test_cobyla_optimizer_with_quadratic_constraint(self):
         """ Cobyla Optimizer Test """
         # load optimization problem
-        problem = OptimizationProblem()
+        problem = QuadraticProgram()
         problem.variables.add(lb=[0, 0], ub=[1, 1], types='CC')
         problem.objective.set_linear([(0, 1), (1, 1)])
 

--- a/test/optimization/test_converters.py
+++ b/test/optimization/test_converters.py
@@ -17,15 +17,16 @@
 import unittest
 from test.optimization.optimization_test_case import QiskitOptimizationTestCase
 import logging
+from docplex.mp.model import Model
 
 from qiskit.aqua.operators import WeightedPauliOperator
 from qiskit.aqua.algorithms import NumPyMinimumEigensolver
 from docplex.mp.model import Model
-from qiskit.optimization import OptimizationProblem, QiskitOptimizationError
+from qiskit.optimization import QuadraticProgram, QiskitOptimizationError
 from qiskit.optimization.results import OptimizationResult
 from qiskit.optimization.converters import (
     InequalityToEqualityConverter,
-    OptimizationProblemToOperator,
+    QuadraticProgramToOperator,
     IntegerToBinaryConverter,
     PenalizeLinearEqualityConstraints,
 )
@@ -69,60 +70,60 @@ class TestConverters(QiskitOptimizationTestCase):
 
     def test_empty_problem(self):
         """ Test empty problem """
-        op = OptimizationProblem()
+        op = QuadraticProgram()
         conv = InequalityToEqualityConverter()
         op = conv.encode(op)
         conv = IntegerToBinaryConverter()
         op = conv.encode(op)
         conv = PenalizeLinearEqualityConstraints()
         op = conv.encode(op)
-        conv = OptimizationProblemToOperator()
+        conv = QuadraticProgramToOperator()
         _, shift = conv.encode(op)
         self.assertEqual(shift, 0.0)
 
     def test_valid_variable_type(self):
-        """Validate the types of the variables for OptimizationProblemToOperator."""
+        """Validate the types of the variables for QuadraticProgramToOperator."""
         # Integer variable
         with self.assertRaises(QiskitOptimizationError):
-            op = OptimizationProblem()
+            op = QuadraticProgram()
             op.variables.add(names=['x'], types='I')
-            conv = OptimizationProblemToOperator()
+            conv = QuadraticProgramToOperator()
             _ = conv.encode(op)
         # Continuous variable
         with self.assertRaises(QiskitOptimizationError):
-            op = OptimizationProblem()
+            op = QuadraticProgram()
             op.variables.add(names=['x'], types='C')
-            conv = OptimizationProblemToOperator()
+            conv = QuadraticProgramToOperator()
             _ = conv.encode(op)
         # Semi-Continuous variable
         with self.assertRaises(QiskitOptimizationError):
-            op = OptimizationProblem()
+            op = QuadraticProgram()
             op.variables.add(names=['x'], types='S')
-            conv = OptimizationProblemToOperator()
+            conv = QuadraticProgramToOperator()
             _ = conv.encode(op)
         # Semi-Integer variable
         with self.assertRaises(QiskitOptimizationError):
-            op = OptimizationProblem()
+            op = QuadraticProgram()
             op.variables.add(names=['x'], types='N')
-            conv = OptimizationProblemToOperator()
+            conv = QuadraticProgramToOperator()
             _ = conv.encode(op)
         # validate the types of the variables for InequalityToEqualityConverter
         # Semi-Continuous variable
         with self.assertRaises(QiskitOptimizationError):
-            op = OptimizationProblem()
+            op = QuadraticProgram()
             op.variables.add(names=['x'], types='S')
             conv = InequalityToEqualityConverter()
             _ = conv.encode(op)
         # Semi-Integer variable
         with self.assertRaises(QiskitOptimizationError):
-            op = OptimizationProblem()
+            op = QuadraticProgram()
             op.variables.add(names=['x'], types='N')
             conv = InequalityToEqualityConverter()
             _ = conv.encode(op)
 
     def test_inequality_binary(self):
         """ Test InequalityToEqualityConverter with binary variables """
-        op = OptimizationProblem()
+        op = QuadraticProgram()
         op.variables.add(names=['x', 'y', 'z'], types='B' * 3)
         op.linear_constraints.add(
             lin_expr=[
@@ -148,7 +149,7 @@ class TestConverters(QiskitOptimizationTestCase):
 
     def test_inequality_integer(self):
         """ Test InequalityToEqualityConverter with integer variables """
-        op = OptimizationProblem()
+        op = QuadraticProgram()
         op.variables.add(names=['x', 'y', 'z'], types='I' * 3, lb=[-3] * 3, ub=[3] * 3)
         op.linear_constraints.add(
             lin_expr=[
@@ -174,7 +175,7 @@ class TestConverters(QiskitOptimizationTestCase):
 
     def test_inequality_mode_integer(self):
         """ Test integer mode of InequalityToEqualityConverter() """
-        op = OptimizationProblem()
+        op = QuadraticProgram()
         op.variables.add(names=['x', 'y', 'z'], types='B' * 3)
         op.linear_constraints.add(
             lin_expr=[
@@ -193,7 +194,7 @@ class TestConverters(QiskitOptimizationTestCase):
 
     def test_inequality_mode_continuous(self):
         """ Test continuous mode of InequalityToEqualityConverter() """
-        op = OptimizationProblem()
+        op = QuadraticProgram()
         op.variables.add(names=['x', 'y', 'z'], types='B' * 3)
         op.linear_constraints.add(
             lin_expr=[
@@ -212,7 +213,7 @@ class TestConverters(QiskitOptimizationTestCase):
 
     def test_inequality_mode_auto(self):
         """ Test auto mode of InequalityToEqualityConverter() """
-        op = OptimizationProblem()
+        op = QuadraticProgram()
         op.variables.add(names=['x', 'y', 'z'], types='B' * 3)
         op.linear_constraints.add(
             lin_expr=[
@@ -231,7 +232,7 @@ class TestConverters(QiskitOptimizationTestCase):
 
     def test_penalize_sense(self):
         """ Test PenalizeLinearEqualityConstraints with senses """
-        op = OptimizationProblem()
+        op = QuadraticProgram()
         op.variables.add(names=['x', 'y', 'z'], types='B' * 3)
         op.linear_constraints.add(
             lin_expr=[
@@ -250,7 +251,7 @@ class TestConverters(QiskitOptimizationTestCase):
 
     def test_penalize_binary(self):
         """ Test PenalizeLinearEqualityConstraints with binary variables """
-        op = OptimizationProblem()
+        op = QuadraticProgram()
         op.variables.add(names=['x', 'y', 'z'], types='B' * 3)
         op.linear_constraints.add(
             lin_expr=[
@@ -268,7 +269,7 @@ class TestConverters(QiskitOptimizationTestCase):
 
     def test_penalize_integer(self):
         """ Test PenalizeLinearEqualityConstraints with integer variables """
-        op = OptimizationProblem()
+        op = QuadraticProgram()
         op.variables.add(names=['x', 'y', 'z'], types='I' * 3, lb=[-3] * 3, ub=[3] * 3)
         op.linear_constraints.add(
             lin_expr=[
@@ -286,7 +287,7 @@ class TestConverters(QiskitOptimizationTestCase):
 
     def test_integer_to_binary(self):
         """ Test integer to binary """
-        op = OptimizationProblem()
+        op = QuadraticProgram()
         op.variables.add(names=['x', 'y', 'z'], types='BIC', lb=[0, 0, 0], ub=[1, 6, 10])
         op.objective.set_linear([('x', 1), ('y', 2), ('z', 1)])
         op.linear_constraints.add(
@@ -314,7 +315,7 @@ class TestConverters(QiskitOptimizationTestCase):
 
     def test_binary_to_integer(self):
         """ Test binary to integer """
-        op = OptimizationProblem()
+        op = QuadraticProgram()
         op.variables.add(names=['x', 'y', 'z'], types='BIB', lb=[0, 0, 0], ub=[1, 7, 1])
         op.objective.set_linear([('x', 2), ('y', 1), ('z', 1)])
         op.linear_constraints.add(
@@ -333,7 +334,7 @@ class TestConverters(QiskitOptimizationTestCase):
 
     def test_optimizationproblem_to_operator(self):
         """ Test optimization problem to operators"""
-        op = OptimizationProblem()
+        op = QuadraticProgram()
         op.variables.add(names=['a', 'b', 'c', 'd'], types='B' * 4)
         op.objective.set_linear([('a', 1), ('b', 1), ('c', 1), ('d', 1)])
         op.linear_constraints.add(
@@ -344,7 +345,7 @@ class TestConverters(QiskitOptimizationTestCase):
         )
         op.objective.set_sense(-1)
         penalize = PenalizeLinearEqualityConstraints()
-        op2ope = OptimizationProblemToOperator()
+        op2ope = QuadraticProgramToOperator()
         op2 = penalize.encode(op)
         qubitop, offset = op2ope.encode(op2)
         self.assertListEqual(qubitop.paulis, QUBIT_OP_MAXIMIZE_SAMPLE.paulis)
@@ -354,7 +355,7 @@ class TestConverters(QiskitOptimizationTestCase):
         """ Test quadratic constraints"""
         # IntegerToBinaryConverter
         with self.assertRaises(QiskitOptimizationError):
-            op = OptimizationProblem()
+            op = QuadraticProgram()
             op.variables.add(names=['x', 'y'])
             l_expr = SparsePair(ind=['x'], val=[1.0])
             q_expr = [['x'], ['y'], [1]]
@@ -363,7 +364,7 @@ class TestConverters(QiskitOptimizationTestCase):
             _ = conv.encode(op)
         # InequalityToEqualityConverter
         with self.assertRaises(QiskitOptimizationError):
-            op = OptimizationProblem()
+            op = QuadraticProgram()
             op.variables.add(names=['x', 'y'])
             l_expr = SparsePair(ind=['x'], val=[1.0])
             q_expr = [['x'], ['y'], [1]]
@@ -377,7 +378,7 @@ class TestConverters(QiskitOptimizationTestCase):
         c = mdl.continuous_var(lb=0, ub=10.9, name='c')
         x = mdl.binary_var(name='x')
         mdl.maximize(c + x * x)
-        op = OptimizationProblem()
+        op = QuadraticProgram()
         op.from_docplex(mdl)
         converter = IntegerToBinaryConverter()
         op = converter.encode(op)

--- a/test/optimization/test_cplex_optimizer.py
+++ b/test/optimization/test_cplex_optimizer.py
@@ -18,7 +18,7 @@ import unittest
 from test.optimization.optimization_test_case import QiskitOptimizationTestCase
 from ddt import ddt, data
 from qiskit.optimization.algorithms import CplexOptimizer
-from qiskit.optimization.problems import OptimizationProblem
+from qiskit.optimization.problems import QuadraticProgram
 
 
 @ddt
@@ -44,7 +44,7 @@ class TestCplexOptimizer(QiskitOptimizationTestCase):
         filename, x, fval = config
 
         # load optimization problem
-        problem = OptimizationProblem()
+        problem = QuadraticProgram()
         problem.read(self.resource_path + filename)
 
         # solve problem with cplex

--- a/test/optimization/test_grover_minimum_finder.py
+++ b/test/optimization/test_grover_minimum_finder.py
@@ -19,7 +19,7 @@ from test.optimization import QiskitOptimizationTestCase
 import numpy as np
 from qiskit.aqua.algorithms import NumPyMinimumEigensolver
 from qiskit.optimization.algorithms import GroverMinimumFinder, MinimumEigenOptimizer
-from qiskit.optimization.problems import OptimizationProblem
+from qiskit.optimization.problems import QuadraticProgram
 
 
 class TestGroverMinimumFinder(QiskitOptimizationTestCase):
@@ -47,7 +47,7 @@ class TestGroverMinimumFinder(QiskitOptimizationTestCase):
         """Test for when the answer is zero."""
         try:
             # Input.
-            op = OptimizationProblem()
+            op = QuadraticProgram()
             op.variables.add(names=['x0', 'x1'], types='BB')
             linear = [('x0', 0), ('x1', 0)]
             op.objective.set_linear(linear)
@@ -64,7 +64,7 @@ class TestGroverMinimumFinder(QiskitOptimizationTestCase):
         """Test for simple case, with 2 linear coeffs and no quadratic coeffs or constants."""
         try:
             # Input.
-            op = OptimizationProblem()
+            op = QuadraticProgram()
             op.variables.add(names=['x0', 'x1'], types='BB')
             linear = [('x0', -1), ('x1', 2)]
             op.objective.set_linear(linear)
@@ -81,7 +81,7 @@ class TestGroverMinimumFinder(QiskitOptimizationTestCase):
         """Test the example from https://arxiv.org/abs/1912.04088."""
         try:
             # Input.
-            op = OptimizationProblem()
+            op = QuadraticProgram()
             op.variables.add(names=['x0', 'x1', 'x2'], types='BBB')
 
             linear = [('x0', -1), ('x1', 2), ('x2', -3)]

--- a/test/optimization/test_linear_constraints.py
+++ b/test/optimization/test_linear_constraints.py
@@ -18,7 +18,7 @@ import unittest
 from test.optimization.optimization_test_case import QiskitOptimizationTestCase
 import logging
 
-from qiskit.optimization import OptimizationProblem
+from qiskit.optimization import QuadraticProgram
 
 logger = logging.getLogger(__name__)
 
@@ -40,13 +40,13 @@ class TestLinearConstraints(QiskitOptimizationTestCase):
 
     def test_get_num(self):
         """ test get num """
-        op = OptimizationProblem()
+        op = QuadraticProgram()
         op.linear_constraints.add(names=["c1", "c2", "c3"])
         self.assertEqual(op.linear_constraints.get_num(), 3)
 
     def test_add(self):
         """ test add """
-        op = OptimizationProblem()
+        op = QuadraticProgram()
         op.variables.add(names=["x1", "x2", "x3"])
         op.linear_constraints.add(
             lin_expr=[SparsePair(ind=["x1", "x3"], val=[1.0, -1.0]),
@@ -61,7 +61,7 @@ class TestLinearConstraints(QiskitOptimizationTestCase):
 
     def test_delete(self):
         """ test delete """
-        op = OptimizationProblem()
+        op = QuadraticProgram()
         op.linear_constraints.add(names=[str(i) for i in range(10)])
         self.assertEqual(op.linear_constraints.get_num(), 10)
         op.linear_constraints.delete(8)
@@ -76,7 +76,7 @@ class TestLinearConstraints(QiskitOptimizationTestCase):
 
     def test_rhs(self):
         """ test rhs """
-        op = OptimizationProblem()
+        op = QuadraticProgram()
         op.linear_constraints.add(names=["c0", "c1", "c2", "c3"])
         self.assertListEqual(op.linear_constraints.get_rhs(), [0.0, 0.0, 0.0, 0.0])
         op.linear_constraints.set_rhs("c1", 1.0)
@@ -86,7 +86,7 @@ class TestLinearConstraints(QiskitOptimizationTestCase):
 
     def test_set_names(self):
         """ test set names """
-        op = OptimizationProblem()
+        op = QuadraticProgram()
         op.linear_constraints.add(names=["c0", "c1", "c2", "c3"])
         op.linear_constraints.set_names("c1", "second")
         self.assertEqual(op.linear_constraints.get_names(1), 'second')
@@ -95,7 +95,7 @@ class TestLinearConstraints(QiskitOptimizationTestCase):
 
     def test_set_senses(self):
         """ test set senses """
-        op = OptimizationProblem()
+        op = QuadraticProgram()
         op.linear_constraints.add(names=["c0", "c1", "c2", "c3"])
         self.assertListEqual(op.linear_constraints.get_senses(), ['E', 'E', 'E', 'E'])
         op.linear_constraints.set_senses("c1", "G")
@@ -105,7 +105,7 @@ class TestLinearConstraints(QiskitOptimizationTestCase):
 
     def test_set_linear_components(self):
         """ test set linear components """
-        op = OptimizationProblem()
+        op = QuadraticProgram()
         op.linear_constraints.add(names=["c0", "c1", "c2", "c3"])
         op.variables.add(names=["x0", "x1"])
         op.linear_constraints.set_linear_components("c0", [["x0"], [1.0]])
@@ -125,7 +125,7 @@ class TestLinearConstraints(QiskitOptimizationTestCase):
 
     def test_set_range_values(self):
         """ test set range values """
-        op = OptimizationProblem()
+        op = QuadraticProgram()
         op.linear_constraints.add(names=["c0", "c1", "c2", "c3"])
         op.linear_constraints.set_range_values("c1", 1.0)
         self.assertListEqual(op.linear_constraints.get_range_values(), [0.0, 1.0, 0.0, 0.0])
@@ -134,7 +134,7 @@ class TestLinearConstraints(QiskitOptimizationTestCase):
 
     def test_set_coeffients(self):
         """ test set coefficients """
-        op = OptimizationProblem()
+        op = QuadraticProgram()
         op.linear_constraints.add(names=["c0", "c1", "c2", "c3"])
         op.variables.add(names=["x0", "x1"])
         op.linear_constraints.set_coefficients("c0", "x1", 1.0)
@@ -149,7 +149,7 @@ class TestLinearConstraints(QiskitOptimizationTestCase):
 
     def test_get_rhs(self):
         """ test get rhs """
-        op = OptimizationProblem()
+        op = QuadraticProgram()
         op.linear_constraints.add(rhs=[1.5 * i for i in range(10)],
                                   names=[str(i) for i in range(10)])
         self.assertEqual(op.linear_constraints.get_num(), 10)
@@ -160,7 +160,7 @@ class TestLinearConstraints(QiskitOptimizationTestCase):
 
     def test_get_senses(self):
         """ test get senses """
-        op = OptimizationProblem()
+        op = QuadraticProgram()
         op.linear_constraints.add(
             senses=["E", "G", "L", "R"],
             names=[str(i) for i in range(4)])
@@ -172,7 +172,7 @@ class TestLinearConstraints(QiskitOptimizationTestCase):
 
     def test_get_range_values(self):
         """ test get range values """
-        op = OptimizationProblem()
+        op = QuadraticProgram()
         op.linear_constraints.add(
             range_values=[1.5 * i for i in range(10)],
             senses=["R"] * 10,
@@ -186,7 +186,7 @@ class TestLinearConstraints(QiskitOptimizationTestCase):
 
     def test_get_coefficients(self):
         """ test get coefficients """
-        op = OptimizationProblem()
+        op = QuadraticProgram()
         op.variables.add(names=["x0", "x1"])
         op.linear_constraints.add(
             names=["c0", "c1"],
@@ -197,7 +197,7 @@ class TestLinearConstraints(QiskitOptimizationTestCase):
 
     def test_get_rows(self):
         """ test get rows """
-        op = OptimizationProblem()
+        op = QuadraticProgram()
         op.variables.add(names=["x1", "x2", "x3"])
         op.linear_constraints.add(
             names=["c0", "c1", "c2", "c3"],
@@ -235,7 +235,7 @@ class TestLinearConstraints(QiskitOptimizationTestCase):
 
     def test_get_num_nonzeros(self):
         """ test get num non zeros """
-        op = OptimizationProblem()
+        op = QuadraticProgram()
         op.variables.add(names=["x1", "x2", "x3"])
         op.linear_constraints.add(
             names=["c0", "c1", "c2", "c3"],
@@ -249,7 +249,7 @@ class TestLinearConstraints(QiskitOptimizationTestCase):
 
     def test_get_names(self):
         """ test get names """
-        op = OptimizationProblem()
+        op = QuadraticProgram()
         op.linear_constraints.add(names=["c" + str(i) for i in range(10)])
         self.assertEqual(op.linear_constraints.get_num(), 10)
         self.assertEqual(op.linear_constraints.get_names(8), 'c8')
@@ -259,13 +259,13 @@ class TestLinearConstraints(QiskitOptimizationTestCase):
 
     def test_get_histogram(self):
         """ test get histogram """
-        op = OptimizationProblem()
+        op = QuadraticProgram()
         with self.assertRaises(NotImplementedError):
             op.linear_constraints.get_histogram()
 
     def test_empty_names(self):
         """ test empty names """
-        op = OptimizationProblem()
+        op = QuadraticProgram()
         r = op.linear_constraints.add(names=['', '', ''])
         self.assertListEqual(op.linear_constraints.get_names(), ['c1', 'c2', 'c3'])
         self.assertEqual(r, range(0, 3))

--- a/test/optimization/test_min_eigen_optimizer.py
+++ b/test/optimization/test_min_eigen_optimizer.py
@@ -25,7 +25,7 @@ from qiskit.aqua.algorithms import QAOA
 from qiskit.aqua.components.optimizers import COBYLA
 
 from qiskit.optimization.algorithms import MinimumEigenOptimizer, CplexOptimizer
-from qiskit.optimization.problems import OptimizationProblem
+from qiskit.optimization.problems import QuadraticProgram
 
 
 @ddt
@@ -67,7 +67,7 @@ class TestMinEigenOptimizer(QiskitOptimizationTestCase):
             min_eigen_optimizer = MinimumEigenOptimizer(min_eigen_solver)
 
             # load optimization problem
-            problem = OptimizationProblem()
+            problem = QuadraticProgram()
             problem.read(self.resource_path + filename)
 
             # solve problem with cplex

--- a/test/optimization/test_objective.py
+++ b/test/optimization/test_objective.py
@@ -18,7 +18,7 @@ import unittest
 from test.optimization.optimization_test_case import QiskitOptimizationTestCase
 import logging
 
-from qiskit.optimization import OptimizationProblem, QiskitOptimizationError
+from qiskit.optimization import QuadraticProgram, QiskitOptimizationError
 
 logger = logging.getLogger(__name__)
 
@@ -40,7 +40,7 @@ class TestObjective(QiskitOptimizationTestCase):
 
     def test_obj_sense(self):
         """ test obj sense """
-        op = OptimizationProblem()
+        op = QuadraticProgram()
         self.assertEqual(op.objective.sense.minimize, 1)
         self.assertEqual(op.objective.sense.maximize, -1)
         self.assertEqual(op.objective.sense[1], 'minimize')
@@ -48,7 +48,7 @@ class TestObjective(QiskitOptimizationTestCase):
 
     def test_set_linear(self):
         """ test set linear """
-        op = OptimizationProblem()
+        op = QuadraticProgram()
         n = 4
         op.variables.add(names=[str(i) for i in range(n)])
         self.assertListEqual(op.objective.get_linear(), [0.0, 0.0, 0.0, 0.0])
@@ -65,14 +65,14 @@ class TestObjective(QiskitOptimizationTestCase):
 
     def test_set_empty_quadratic(self):
         """ test set empty quadratic """
-        op = OptimizationProblem()
+        op = QuadraticProgram()
         self.assertIsNone(op.objective.set_quadratic([]))
         with self.assertRaises(TypeError):
             op.objective.set_quadratic()
 
     def test_set_quadratic(self):
         """ test set quadratic """
-        op = OptimizationProblem()
+        op = QuadraticProgram()
         n = 3
         op.variables.add(names=[str(i) for i in range(n)])
         obj = op.objective
@@ -107,7 +107,7 @@ class TestObjective(QiskitOptimizationTestCase):
 
     def test_get_quadratic_dict(self):
         """ test get quadratic dict """
-        op = OptimizationProblem()
+        op = QuadraticProgram()
         op.variables.add(names=['x', 'y'])
         op.objective.set_quadratic_coefficients([('x', 'x', 1), ('x', 'y', 2)])
         self.assertDictEqual(op.objective.get_quadratic_dict(),
@@ -115,7 +115,7 @@ class TestObjective(QiskitOptimizationTestCase):
 
     def test_set_quadratic_coefficients(self):
         """ test set quadratic coefficients """
-        op = OptimizationProblem()
+        op = QuadraticProgram()
         n = 3
         op.variables.add(names=[str(i) for i in range(n)])
         obj = op.objective
@@ -150,7 +150,7 @@ class TestObjective(QiskitOptimizationTestCase):
 
     def test_set_senses(self):
         """ test set senses """
-        op = OptimizationProblem()
+        op = QuadraticProgram()
         self.assertEqual(op.objective.sense[op.objective.get_sense()], 'minimize')
         op.objective.set_sense(op.objective.sense.maximize)
         self.assertEqual(op.objective.sense[op.objective.get_sense()], 'maximize')
@@ -159,13 +159,13 @@ class TestObjective(QiskitOptimizationTestCase):
 
     def test_set_name(self):
         """ test set name """
-        op = OptimizationProblem()
+        op = QuadraticProgram()
         op.objective.set_name('cost')
         self.assertEqual(op.objective.get_name(), 'cost')
 
     def test_get_linear(self):
         """ test get linear """
-        op = OptimizationProblem()
+        op = QuadraticProgram()
         n = 10
         op.variables.add(names=[str(i) for i in range(n)])
         obj = op.objective
@@ -179,14 +179,14 @@ class TestObjective(QiskitOptimizationTestCase):
 
     def test_get_linear_dict(self):
         """ test get linear dict """
-        op = OptimizationProblem()
+        op = QuadraticProgram()
         op.variables.add(names=['x', 'y'])
         op.objective.set_linear([('x', 1), ('y', 2)])
         self.assertDictEqual(op.objective.get_linear_dict(), {0: 1, 1: 2})
 
     def test_get_quadratic(self):
         """ test get quadratic """
-        op = OptimizationProblem()
+        op = QuadraticProgram()
         n = 10
         op.variables.add(names=[str(i) for i in range(n)])
         obj = op.objective
@@ -222,7 +222,7 @@ class TestObjective(QiskitOptimizationTestCase):
 
     def test_get_quadratic_coefficients(self):
         """ test get quadratic coefficients """
-        op = OptimizationProblem()
+        op = QuadraticProgram()
         n = 3
         op.variables.add(names=[str(i) for i in range(n)])
         obj = op.objective
@@ -236,7 +236,7 @@ class TestObjective(QiskitOptimizationTestCase):
 
     def test_get_sense(self):
         """ test get sense """
-        op = OptimizationProblem()
+        op = QuadraticProgram()
         self.assertEqual(op.objective.sense[op.objective.get_sense()], 'minimize')
         op.objective.set_sense(op.objective.sense.maximize)
         self.assertEqual(op.objective.sense[op.objective.get_sense()], 'maximize')
@@ -245,13 +245,13 @@ class TestObjective(QiskitOptimizationTestCase):
 
     def test_get_name(self):
         """ test get name """
-        op = OptimizationProblem()
+        op = QuadraticProgram()
         op.objective.set_name('cost')
         self.assertEqual(op.objective.get_name(), 'cost')
 
     def test_get_num_quadratic_variables(self):
         """ test get num quadratic variables """
-        op = OptimizationProblem()
+        op = QuadraticProgram()
         n = 3
         op.variables.add(names=[str(i) for i in range(n)])
         obj = op.objective
@@ -264,7 +264,7 @@ class TestObjective(QiskitOptimizationTestCase):
 
     def test_get_num_quadratic_nonzeros(self):
         """ test get num quadratic non zeros """
-        op = OptimizationProblem()
+        op = QuadraticProgram()
         n = 3
         op.variables.add(names=[str(i) for i in range(n)])
         obj = op.objective
@@ -277,14 +277,14 @@ class TestObjective(QiskitOptimizationTestCase):
 
     def test_offset(self):
         """ test offset """
-        op = OptimizationProblem()
+        op = QuadraticProgram()
         self.assertEqual(op.objective.get_offset(), 0.0)
         op.objective.set_offset(3.14)
         self.assertEqual(op.objective.get_offset(), 3.14)
 
     def test_set_quadratic_coefficients2(self):
         """ test set quadratic coefficients 2 """
-        op = OptimizationProblem()
+        op = QuadraticProgram()
         n = 2
         op.variables.add(names=[str(i) for i in range(n)])
         obj = op.objective
@@ -297,7 +297,7 @@ class TestObjective(QiskitOptimizationTestCase):
 
     def test_default_name(self):
         """ test default name """
-        op = OptimizationProblem()
+        op = QuadraticProgram()
         self.assertEqual(op.objective.get_name(), 'obj1')
 
 

--- a/test/optimization/test_quadratic_constraints.py
+++ b/test/optimization/test_quadratic_constraints.py
@@ -19,7 +19,7 @@ from test.optimization.optimization_test_case import QiskitOptimizationTestCase
 import logging
 
 from qiskit.optimization import QiskitOptimizationError
-from qiskit.optimization.problems import OptimizationProblem
+from qiskit.optimization.problems import QuadraticProgram
 
 logger = logging.getLogger(__name__)
 
@@ -41,7 +41,7 @@ class TestQuadraticConstraints(QiskitOptimizationTestCase):
 
     def test_initial1(self):
         """ test initial 1"""
-        op = OptimizationProblem()
+        op = QuadraticProgram()
         c_1 = op.quadratic_constraints.add(name='c1')
         c_2 = op.quadratic_constraints.add(name='c2')
         c_3 = op.quadratic_constraints.add(name='c3')
@@ -53,7 +53,7 @@ class TestQuadraticConstraints(QiskitOptimizationTestCase):
 
     def test_initial2(self):
         """ test initial 2"""
-        op = OptimizationProblem()
+        op = QuadraticProgram()
         op.variables.add(names=['x1', 'x2', 'x3'], types='B' * 3)
         op.quadratic_constraints.add(
             lin_expr=SparsePair(ind=['x1', 'x3'], val=[1.0, -1.0]),
@@ -80,7 +80,7 @@ class TestQuadraticConstraints(QiskitOptimizationTestCase):
 
     def test_initial3(self):
         """ test initial 3"""
-        op = OptimizationProblem()
+        op = QuadraticProgram()
         op.variables.add(names=['x', 'y'])
         with self.assertRaises(QiskitOptimizationError):
             op.quadratic_constraints.add(lin_expr=([0, 0], [1, 1]))
@@ -88,7 +88,7 @@ class TestQuadraticConstraints(QiskitOptimizationTestCase):
 
     def test_get_num(self):
         """ test get num """
-        op = OptimizationProblem()
+        op = QuadraticProgram()
         op.variables.add(names=['x', 'y'])
         lin = SparsePair(ind=['x'], val=[1.0])
         q = SparseTriple(ind1=['x'], ind2=['y'], val=[1.0])
@@ -100,7 +100,7 @@ class TestQuadraticConstraints(QiskitOptimizationTestCase):
 
     def test_add(self):
         """ test add """
-        op = OptimizationProblem()
+        op = QuadraticProgram()
         op.variables.add(names=['x', 'y'])
         lin = SparsePair(ind=['x'], val=[1.0])
         q = SparseTriple(ind1=['x'], ind2=['y'], val=[1.0])
@@ -109,7 +109,7 @@ class TestQuadraticConstraints(QiskitOptimizationTestCase):
 
     def test_delete(self):
         """ test delete """
-        op = OptimizationProblem()
+        op = QuadraticProgram()
         q_0 = [op.quadratic_constraints.add(name=str(i)) for i in range(10)]
         self.assertListEqual(q_0, list(range(10)))
         q = op.quadratic_constraints
@@ -125,7 +125,7 @@ class TestQuadraticConstraints(QiskitOptimizationTestCase):
 
     def test_get_rhs(self):
         """ test get rhs  """
-        op = OptimizationProblem()
+        op = QuadraticProgram()
         op.variables.add(names=[str(i) for i in range(10)])
         q_0 = [op.quadratic_constraints.add(rhs=1.5 * i, name=str(i)) for i in range(10)]
         self.assertListEqual(q_0, list(range(10)))
@@ -138,7 +138,7 @@ class TestQuadraticConstraints(QiskitOptimizationTestCase):
 
     def test_get_senses(self):
         """ test get senses """
-        op = OptimizationProblem()
+        op = QuadraticProgram()
         op.variables.add(names=["x0"])
         q = op.quadratic_constraints
         q_0 = [q.add(name=str(i), sense=j) for i, j in enumerate('GGLL')]
@@ -150,7 +150,7 @@ class TestQuadraticConstraints(QiskitOptimizationTestCase):
 
     def test_get_linear_num_nonzeros(self):
         """ test get linear num non zeros """
-        op = OptimizationProblem()
+        op = QuadraticProgram()
         op.variables.add(names=[str(i) for i in range(11)], types="B" * 11)
         q = op.quadratic_constraints
         n = 10
@@ -165,7 +165,7 @@ class TestQuadraticConstraints(QiskitOptimizationTestCase):
 
     def test_get_linear_components(self):
         """ test get linear components """
-        op = OptimizationProblem()
+        op = QuadraticProgram()
         op.variables.add(names=[str(i) for i in range(4)], types="B" * 4)
         q = op.quadratic_constraints
         z = [q.add(name=str(i),
@@ -199,7 +199,7 @@ class TestQuadraticConstraints(QiskitOptimizationTestCase):
 
     def test_get_linear_components2(self):
         """ test get linear components 2 """
-        op = OptimizationProblem()
+        op = QuadraticProgram()
         op.variables.add(names=[str(i) for i in range(11)], types="B" * 11)
         q = op.quadratic_constraints
         _ = [q.add(name=str(i),
@@ -241,7 +241,7 @@ class TestQuadraticConstraints(QiskitOptimizationTestCase):
 
     def test_quad_num_nonzeros(self):
         """ test quad num non zeros """
-        op = OptimizationProblem()
+        op = QuadraticProgram()
         op.variables.add(names=[str(i) for i in range(11)])
         q = op.quadratic_constraints
         _ = [q.add(name=str(i),
@@ -255,7 +255,7 @@ class TestQuadraticConstraints(QiskitOptimizationTestCase):
 
     def test_get_quadratic_components(self):
         """ test get quadratic components """
-        op = OptimizationProblem()
+        op = QuadraticProgram()
         op.variables.add(names=[str(i) for i in range(4)])
         q = op.quadratic_constraints
         z = [q.add(name="q{0}".format(i),
@@ -295,7 +295,7 @@ class TestQuadraticConstraints(QiskitOptimizationTestCase):
 
     def test_get_quadratic_components2(self):
         """ test get quadratic components 2 """
-        op = OptimizationProblem()
+        op = QuadraticProgram()
         op.variables.add(names=[str(i) for i in range(11)])
         q = op.quadratic_constraints
         _ = [q.add(name=str(i),
@@ -351,7 +351,7 @@ class TestQuadraticConstraints(QiskitOptimizationTestCase):
 
     def test_get_names(self):
         """ test get names """
-        op = OptimizationProblem()
+        op = QuadraticProgram()
         op.variables.add(names=[str(i) for i in range(11)])
         q = op.quadratic_constraints
         _ = [q.add(name="q" + str(i),
@@ -366,7 +366,7 @@ class TestQuadraticConstraints(QiskitOptimizationTestCase):
 
     def test_empty_names(self):
         """ test empty names """
-        op = OptimizationProblem()
+        op = QuadraticProgram()
         op.variables.add(names=['x'])
         op.quadratic_constraints.add(name='a')
         op.quadratic_constraints.add(name='')

--- a/test/optimization/test_quadratic_program.py
+++ b/test/optimization/test_quadratic_program.py
@@ -12,7 +12,7 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
-""" Test OptimizationProblem """
+""" Test QuadraticProgram """
 
 import os.path
 import tempfile
@@ -20,8 +20,8 @@ import unittest
 from test.optimization.optimization_test_case import QiskitOptimizationTestCase
 import logging
 
-from qiskit.optimization import OptimizationProblem, QiskitOptimizationError
-from qiskit.optimization.problems.optimization_problem import SubstitutionStatus
+from qiskit.optimization import QuadraticProgram, QiskitOptimizationError
+from qiskit.optimization.problems.quadratic_program import SubstitutionStatus
 
 logger = logging.getLogger(__name__)
 
@@ -33,8 +33,8 @@ except ImportError:
     logger.info('CPLEX is not installed.')
 
 
-class TestOptimizationProblem(QiskitOptimizationTestCase):
-    """Test OptimizationProblem without the members that have separate test classes
+class TestQuadraticProgram(QiskitOptimizationTestCase):
+    """Test QuadraticProgram without the members that have separate test classes
     (VariablesInterface, etc)."""
 
     def setUp(self):
@@ -46,7 +46,7 @@ class TestOptimizationProblem(QiskitOptimizationTestCase):
 
     def test_constructor1(self):
         """ test constructor """
-        op = OptimizationProblem()
+        op = QuadraticProgram()
         self.assertEqual(op.get_problem_name(), '')
         op.variables.add(names=['x1', 'x2', 'x3'])
         self.assertEqual(op.variables.get_num(), 3)
@@ -54,34 +54,34 @@ class TestOptimizationProblem(QiskitOptimizationTestCase):
     def test_constructor2(self):
         """ test constructor 2 """
         with self.assertRaises(QiskitOptimizationError):
-            _ = OptimizationProblem("unknown")
+            _ = QuadraticProgram("unknown")
         # If filename does not exist, an exception is raised.
 
     def test_constructor_context(self):
         """ test constructor context """
-        with OptimizationProblem() as op:
+        with QuadraticProgram() as op:
             op.variables.add(names=['x1', 'x2', 'x3'])
             self.assertEqual(op.variables.get_num(), 3)
 
     def test_end(self):
         """ test end """
-        op = OptimizationProblem()
+        op = QuadraticProgram()
         self.assertIsNone(op.end())
 
     def test_solve(self):
         """ test solve """
-        op = OptimizationProblem()
+        op = QuadraticProgram()
         self.assertIsNone(op.solve())
 
     def test_read1(self):
         """ test read 1"""
-        op = OptimizationProblem()
+        op = QuadraticProgram()
         op.read(self.resource_file)
         self.assertEqual(op.variables.get_num(), 3)
 
     def test_write1(self):
         """ test write 1 """
-        op = OptimizationProblem()
+        op = QuadraticProgram()
         op.variables.add(names=['x1', 'x2', 'x3'])
         file, filename = tempfile.mkstemp(suffix='.lp')
         os.close(file)
@@ -90,18 +90,18 @@ class TestOptimizationProblem(QiskitOptimizationTestCase):
 
     def test_write2(self):
         """ test write 2 """
-        op1 = OptimizationProblem()
+        op1 = QuadraticProgram()
         op1.variables.add(names=['x1', 'x2', 'x3'])
         file, filename = tempfile.mkstemp(suffix='.lp')
         os.close(file)
         op1.write(filename)
-        op2 = OptimizationProblem()
+        op2 = QuadraticProgram()
         op2.read(filename)
         self.assertEqual(op2.variables.get_num(), 3)
 
     def test_write3(self):
         """ test write 3 """
-        op = OptimizationProblem()
+        op = QuadraticProgram()
         op.variables.add(names=['x1', 'x2', 'x3'])
 
         class NoOpStream:
@@ -129,28 +129,28 @@ class TestOptimizationProblem(QiskitOptimizationTestCase):
     def test_write4(self):
         """ test write 4 """
         # Writes a problem as a string in the given file format.
-        op = OptimizationProblem()
+        op = QuadraticProgram()
         op.variables.add(names=['x1', 'x2', 'x3'])
         lp_str = op.write_as_string("lp")
         self.assertGreater(len(lp_str), 0)
 
     def test_problem_type1(self):
         """ test problem type 1 """
-        op = OptimizationProblem()
+        op = QuadraticProgram()
         op.read(self.resource_file)
         self.assertEqual(op.get_problem_type(), op.problem_type.QP)
         self.assertEqual(op.problem_type[op.get_problem_type()], 'QP')
 
     def test_problem_type2(self):
         """ test problem type 2"""
-        op = OptimizationProblem()
+        op = QuadraticProgram()
         op.set_problem_type(op.problem_type.LP)
         self.assertEqual(op.get_problem_type(), op.problem_type.LP)
         self.assertEqual(op.problem_type[op.get_problem_type()], 'LP')
 
     def test_problem_type3(self):
         """ test problem type 3"""
-        op = OptimizationProblem()
+        op = QuadraticProgram()
         self.assertEqual(op.get_problem_type(), op.problem_type.LP)
         op.variables.add(names=['x1', 'x2', 'x3'], types='B' * 3)
         op.objective.set_linear([('x1', 2.0), ('x3', 0.5)])
@@ -181,7 +181,7 @@ class TestOptimizationProblem(QiskitOptimizationTestCase):
 
     def test_problem_name(self):
         """ test problem name """
-        op = OptimizationProblem()
+        op = QuadraticProgram()
         op.set_problem_name("test")
         # test
         self.assertEqual(op.get_problem_name(), "test")
@@ -212,7 +212,7 @@ class TestOptimizationProblem(QiskitOptimizationTestCase):
             rhs=1.0
         )
         orig = op.write_as_string()
-        op2 = OptimizationProblem()
+        op2 = QuadraticProgram()
         op2.from_cplex(op)
         self.assertEqual(op2.write_as_string(), orig)
         op3 = op2.to_cplex()
@@ -220,7 +220,7 @@ class TestOptimizationProblem(QiskitOptimizationTestCase):
 
         op.set_problem_name('test')
         orig = op.write_as_string()
-        op2 = OptimizationProblem()
+        op2 = QuadraticProgram()
         op2.from_cplex(op)
         self.assertEqual(op2.write_as_string(), orig)
         op3 = op2.to_cplex()
@@ -228,7 +228,7 @@ class TestOptimizationProblem(QiskitOptimizationTestCase):
 
     def test_substitute_variables_bounds1(self):
         """ test substitute variables bounds 1 """
-        op = OptimizationProblem()
+        op = QuadraticProgram()
         op.set_problem_name('before')
         n = 5
         op.variables.add(names=['x' + str(i) for i in range(n)], types='I' * n,
@@ -246,7 +246,7 @@ class TestOptimizationProblem(QiskitOptimizationTestCase):
 
     def test_substitute_variables_bounds2(self):
         """ test substitute variables bounds 2 """
-        op = OptimizationProblem()
+        op = QuadraticProgram()
         op.set_problem_name('before')
         n = 5
         op.variables.add(names=['x' + str(i) for i in range(n)], types='I' * n,
@@ -264,7 +264,7 @@ class TestOptimizationProblem(QiskitOptimizationTestCase):
 
     def test_substitute_variables_obj(self):
         """ test substitute variables objective """
-        op = OptimizationProblem()
+        op = QuadraticProgram()
         op.set_problem_name('before')
         op.variables.add(names=['x1', 'x2', 'x3'], types='I' * 3, lb=[-2] * 3, ub=[4] * 3)
         op.objective.set_linear([('x1', 1.0), ('x2', 2.0)])
@@ -285,7 +285,7 @@ class TestOptimizationProblem(QiskitOptimizationTestCase):
 
     def test_substitute_variables_lin_cst1(self):
         """ test substitute variables linear constraints 1 """
-        op = OptimizationProblem()
+        op = QuadraticProgram()
         n = 5
         op.variables.add(names=['x' + str(i) for i in range(n)], types='I' * n,
                          lb=[-10] * n, ub=[14] * n)
@@ -326,7 +326,7 @@ class TestOptimizationProblem(QiskitOptimizationTestCase):
 
     def test_substitute_variables_lin_cst2(self):
         """ test substitute variables linear constraints 2 """
-        op = OptimizationProblem()
+        op = QuadraticProgram()
         n = 3
         op.variables.add(names=['x' + str(i) for i in range(n)], types='I' * n,
                          lb=[-2] * n, ub=[4] * n)
@@ -358,7 +358,7 @@ class TestOptimizationProblem(QiskitOptimizationTestCase):
 
     def test_substitute_variables_quad_cst1(self):
         """ test substitute variables quadratic constraints 1 """
-        op = OptimizationProblem()
+        op = QuadraticProgram()
         n = 3
         op.variables.add(names=['x' + str(i) for i in range(n)], types='I' * n,
                          lb=[-2] * n, ub=[4] * n)

--- a/test/optimization/test_quadratic_program_to_negative_value_oracle.py
+++ b/test/optimization/test_quadratic_program_to_negative_value_oracle.py
@@ -17,13 +17,13 @@
 import unittest
 from test.optimization import QiskitOptimizationTestCase
 import numpy as np
-from qiskit.optimization.converters import OptimizationProblemToNegativeValueOracle
+from qiskit.optimization.converters import QuadraticProgramToNegativeValueOracle
 from qiskit.optimization.util import get_qubo_solutions
 from qiskit import QuantumCircuit, Aer, execute
-from qiskit.optimization.problems import OptimizationProblem
+from qiskit.optimization.problems import QuadraticProgram
 
 
-class TestOptimizationProblemToNegativeValueOracle(QiskitOptimizationTestCase):
+class TestQuadraticProgramToNegativeValueOracle(QiskitOptimizationTestCase):
     """OPtNVO Tests"""
 
     def _validate_function(self, func_dict, problem):
@@ -85,7 +85,7 @@ class TestOptimizationProblemToNegativeValueOracle(QiskitOptimizationTestCase):
             num_value = 4
 
             # Input.
-            problem = OptimizationProblem()
+            problem = QuadraticProgram()
             problem.variables.add(names=['x0', 'x1', 'x2'], types='BBB')
             linear = [('x0', -1), ('x1', 2), ('x2', -3)]
             problem.objective.set_linear(linear)
@@ -93,7 +93,7 @@ class TestOptimizationProblemToNegativeValueOracle(QiskitOptimizationTestCase):
             problem.objective.set_quadratic_coefficients('x1', 'x2', -1)
 
             # Convert to dictionary format with operator/oracle.
-            converter = OptimizationProblemToNegativeValueOracle(num_value)
+            converter = QuadraticProgramToNegativeValueOracle(num_value)
             a_operator, _, func_dict = converter.encode(problem)
 
             self._validate_function(func_dict, problem)
@@ -108,7 +108,7 @@ class TestOptimizationProblemToNegativeValueOracle(QiskitOptimizationTestCase):
             num_value = 5
 
             # Input.
-            problem = OptimizationProblem()
+            problem = QuadraticProgram()
             problem.variables.add(names=['x0', 'x1', 'x2'], types='BBB')
             linear = [('x0', -1), ('x1', -2), ('x2', -1)]
             problem.objective.set_linear(linear)
@@ -118,7 +118,7 @@ class TestOptimizationProblemToNegativeValueOracle(QiskitOptimizationTestCase):
             problem.objective.set_offset(-1)
 
             # Convert to dictionary format with operator/oracle.
-            converter = OptimizationProblemToNegativeValueOracle(num_value)
+            converter = QuadraticProgramToNegativeValueOracle(num_value)
             a_operator, _, func_dict = converter.encode(problem)
 
             self._validate_function(func_dict, problem)
@@ -133,7 +133,7 @@ class TestOptimizationProblemToNegativeValueOracle(QiskitOptimizationTestCase):
             num_value = 4
 
             # Input.
-            problem = OptimizationProblem()
+            problem = QuadraticProgram()
             problem.variables.add(names=['x0', 'x1', 'x2', 'x3', 'x4', 'x5'], types='BBBBBB')
             linear = [('x0', -1), ('x1', -2), ('x2', -1), ('x3', 0), ('x4', 1), ('x5', 2)]
             problem.objective.set_linear(linear)
@@ -141,7 +141,7 @@ class TestOptimizationProblemToNegativeValueOracle(QiskitOptimizationTestCase):
             problem.objective.set_quadratic_coefficients('x1', 'x5', -2)
 
             # Convert to dictionary format with operator/oracle.
-            converter = OptimizationProblemToNegativeValueOracle(num_value)
+            converter = QuadraticProgramToNegativeValueOracle(num_value)
             a_operator, _, func_dict = converter.encode(problem)
 
             self._validate_function(func_dict, problem)

--- a/test/optimization/test_recursive_optimization.py
+++ b/test/optimization/test_recursive_optimization.py
@@ -26,7 +26,7 @@ from qiskit.aqua.components.optimizers import COBYLA
 
 from qiskit.optimization.algorithms import (MinimumEigenOptimizer, CplexOptimizer,
                                             RecursiveMinimumEigenOptimizer)
-from qiskit.optimization.problems import OptimizationProblem
+from qiskit.optimization.problems import QuadraticProgram
 
 
 @ddt
@@ -81,7 +81,7 @@ class TestRecursiveMinEigenOptimizer(QiskitOptimizationTestCase):
                                                                            min_num_vars=4)
 
             # load optimization problem
-            problem = OptimizationProblem()
+            problem = QuadraticProgram()
             problem.read(self.resource_path + filename)
 
             # solve problem with cplex

--- a/test/optimization/test_variables.py
+++ b/test/optimization/test_variables.py
@@ -18,7 +18,7 @@ import unittest
 from test.optimization.optimization_test_case import QiskitOptimizationTestCase
 import logging
 
-from qiskit.optimization import OptimizationProblem, QiskitOptimizationError
+from qiskit.optimization import QuadraticProgram, QiskitOptimizationError
 
 logger = logging.getLogger(__name__)
 
@@ -40,13 +40,13 @@ class TestVariables(QiskitOptimizationTestCase):
 
     def test_type(self):
         """ test type """
-        op = OptimizationProblem()
+        op = QuadraticProgram()
         self.assertEqual(op.variables.type.binary, 'B')
         self.assertEqual(op.variables.type['B'], 'binary')
 
     def test_initial(self):
         """ test initial """
-        op = OptimizationProblem()
+        op = QuadraticProgram()
         op.variables.add(names=["x0", "x1", "x2"])
         self.assertListEqual(op.variables.get_lower_bounds(), [0.0, 0.0, 0.0])
         op.variables.set_lower_bounds(0, 1.0)
@@ -59,49 +59,49 @@ class TestVariables(QiskitOptimizationTestCase):
 
     def test_get_num(self):
         """ test get num """
-        op = OptimizationProblem()
+        op = QuadraticProgram()
         typ = op.variables.type
         op.variables.add(types=[typ.continuous, typ.binary, typ.integer])
         self.assertEqual(op.variables.get_num(), 3)
 
     def test_get_num_continuous(self):
         """ test get num continuous """
-        op = OptimizationProblem()
+        op = QuadraticProgram()
         typ = op.variables.type
         op.variables.add(types=[typ.continuous, typ.binary, typ.integer])
         self.assertEqual(op.variables.get_num_continuous(), 1)
 
     def test_get_num_integer(self):
         """ test get num integer """
-        op = OptimizationProblem()
+        op = QuadraticProgram()
         typ = op.variables.type
         op.variables.add(types=[typ.continuous, typ.binary, typ.integer])
         self.assertEqual(op.variables.get_num_integer(), 1)
 
     def test_get_num_binary(self):
         """ test get num binary """
-        op = OptimizationProblem()
+        op = QuadraticProgram()
         typ = op.variables.type
         op.variables.add(types=[typ.semi_continuous, typ.binary, typ.integer])
         self.assertEqual(op.variables.get_num_binary(), 1)
 
     def test_get_num_semicontinuous(self):
         """ test get num semi continuous """
-        op = OptimizationProblem()
+        op = QuadraticProgram()
         typ = op.variables.type
         op.variables.add(types=[typ.semi_continuous, typ.semi_integer, typ.semi_integer])
         self.assertEqual(op.variables.get_num_semicontinuous(), 1)
 
     def test_get_num_semiinteger(self):
         """ test get num semi integer """
-        op = OptimizationProblem()
+        op = QuadraticProgram()
         typ = op.variables.type
         op.variables.add(types=[typ.semi_continuous, typ.semi_integer, typ.semi_integer])
         self.assertEqual(op.variables.get_num_semiinteger(), 2)
 
     def test_add(self):
         """ add test """
-        op = OptimizationProblem()
+        op = QuadraticProgram()
         op.linear_constraints.add(names=["c0", "c1", "c2"])
         op.variables.add(types=[op.variables.type.integer] * 3)
         op.variables.add(
@@ -119,7 +119,7 @@ class TestVariables(QiskitOptimizationTestCase):
 
     def test_delete(self):
         """ test delete """
-        op = OptimizationProblem()
+        op = QuadraticProgram()
         op.variables.add(names=[str(i) for i in range(10)])
         self.assertEqual(op.variables.get_num(), 10)
         self.assertListEqual(op.variables.get_names(),
@@ -136,7 +136,7 @@ class TestVariables(QiskitOptimizationTestCase):
 
     def test_set_lower_bounds(self):
         """ test set lower bounds """
-        op = OptimizationProblem()
+        op = QuadraticProgram()
         op.variables.add(names=["x0", "x1", "x2"])
         op.variables.set_lower_bounds(0, 1.0)
         self.assertListEqual(op.variables.get_lower_bounds(), [1.0, 0.0, 0.0])
@@ -145,7 +145,7 @@ class TestVariables(QiskitOptimizationTestCase):
 
     def test_set_upper_bounds(self):
         """ test set upper bounds """
-        op = OptimizationProblem()
+        op = QuadraticProgram()
         op.variables.add(names=["x0", "x1", "x2"])
         op.variables.set_upper_bounds(0, 1.0)
         op.variables.set_upper_bounds([("x1", 10.0), (2, 3.0)])
@@ -153,7 +153,7 @@ class TestVariables(QiskitOptimizationTestCase):
 
     def test_set_names(self):
         """ test set names """
-        op = OptimizationProblem()
+        op = QuadraticProgram()
         typ = op.variables.type
         op.variables.add(types=[typ.continuous, typ.binary, typ.integer])
         op.variables.set_names(0, "first")
@@ -162,7 +162,7 @@ class TestVariables(QiskitOptimizationTestCase):
 
     def test_set_types(self):
         """ test set types """
-        op = OptimizationProblem()
+        op = QuadraticProgram()
         op.variables.add(names=[str(i) for i in range(5)])
         op.variables.set_types(0, op.variables.type.continuous)
         op.variables.set_types([("1", op.variables.type.integer),
@@ -174,7 +174,7 @@ class TestVariables(QiskitOptimizationTestCase):
 
     def test_get_lower_bounds(self):
         """ test get lower bounds """
-        op = OptimizationProblem()
+        op = QuadraticProgram()
         op.variables.add(lb=[1.5 * i for i in range(10)],
                          names=[str(i) for i in range(10)])
         self.assertEqual(op.variables.get_num(), 10)
@@ -186,7 +186,7 @@ class TestVariables(QiskitOptimizationTestCase):
 
     def test_get_upper_bounds(self):
         """ test get upper bounds """
-        op = OptimizationProblem()
+        op = QuadraticProgram()
         op.variables.add(ub=[(1.5 * i) + 1.0 for i in range(10)],
                          names=[str(i) for i in range(10)])
         self.assertEqual(op.variables.get_num(), 10)
@@ -198,7 +198,7 @@ class TestVariables(QiskitOptimizationTestCase):
 
     def test_get_names(self):
         """ test get names """
-        op = OptimizationProblem()
+        op = QuadraticProgram()
         op.variables.add(names=['x' + str(i) for i in range(10)])
         self.assertEqual(op.variables.get_num(), 10)
         self.assertEqual(op.variables.get_names(8), 'x8')
@@ -209,7 +209,7 @@ class TestVariables(QiskitOptimizationTestCase):
 
     def test_set_types2(self):
         """ test set types 2 """
-        op = OptimizationProblem()
+        op = QuadraticProgram()
         typ = op.variables.type
         op.variables.add(names=[str(i) for i in range(5)],
                          types=[typ.continuous, typ.integer,
@@ -228,26 +228,26 @@ class TestVariables(QiskitOptimizationTestCase):
 
     def test_get_cols(self):
         """ test get cols """
-        op = OptimizationProblem()
+        op = QuadraticProgram()
         with self.assertRaises(NotImplementedError):
             op.variables.get_cols()
 
     def test_get_obj(self):
         """ test get obj """
-        op = OptimizationProblem()
+        op = QuadraticProgram()
         with self.assertRaises(NotImplementedError):
             op.variables.get_obj()
 
     def test_get_indices(self):
         """ test get indices """
-        op = OptimizationProblem()
+        op = QuadraticProgram()
         op.variables.add(names=['a', 'b'])
         self.assertEqual(op.variables.get_indices('a'), 0)
         self.assertListEqual(op.variables.get_indices(['a', 'b']), [0, 1])
 
     def test_add2(self):
         """ test add2 """
-        op = OptimizationProblem()
+        op = QuadraticProgram()
         op.variables.add(names=['x'])
         self.assertEqual(op.variables.get_indices('x'), 0)
         self.assertListEqual(op.variables.get_indices(), [0])
@@ -258,7 +258,7 @@ class TestVariables(QiskitOptimizationTestCase):
 
     def test_default_bounds(self):
         """  test default bounds """
-        op = OptimizationProblem()
+        op = QuadraticProgram()
         types = ['B', 'I', 'C', 'S', 'N']
         op.variables.add(names=types, types=types)
         self.assertListEqual(op.variables.get_lower_bounds(), [0.0] * 5)
@@ -267,7 +267,7 @@ class TestVariables(QiskitOptimizationTestCase):
 
     def test_empty_names(self):
         """ test empty names """
-        op = OptimizationProblem()
+        op = QuadraticProgram()
         r = op.variables.add(names=['', '', ''])
         self.assertEqual(r, range(0, 3))
         self.assertListEqual(op.variables.get_names(), ['x1', 'x2', 'x3'])
@@ -278,7 +278,7 @@ class TestVariables(QiskitOptimizationTestCase):
 
     def test_duplicate_names(self):
         """ test duplicate names """
-        op = OptimizationProblem()
+        op = QuadraticProgram()
         op.variables.add(names=['', '', ''])
         with self.assertRaises(QiskitOptimizationError):
             op.variables.add(names=['a', 'a'])
@@ -287,7 +287,7 @@ class TestVariables(QiskitOptimizationTestCase):
 
     def test_add3(self):
         """ test add 3 """
-        op = OptimizationProblem()
+        op = QuadraticProgram()
         op.variables.add(names=['c'], types=['C'], lb=[-10], ub=[10])
         op.variables.add(names=['b'], types=['B'], lb=[-10], ub=[10])
         op.variables.add(names=['b2'], types=['B'])


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

The `is_compatible` checks is an optimization problem is compatible with the optimization algorithm. It currently returns a string with the error message if there are incompatibilities or None if there aren't any. This should be changed to returning a bool due to the naming `is_*`, where users probably expect a boolean return value. Also the raising of the error must be done on top of the creating the message, which should be done inside the method. 

If there are scenarios where `is_compatible` should not raise an error but just return the message we could add a keyword argument `raise_on_failure` which can be set to `False` and then the error message is returned instead.


