### PR TITLE
Deal with asymmetric input for QuadraticExpression

### DIFF
--- a/qiskit/optimization/problems/quadratic_expression.py
+++ b/qiskit/optimization/problems/quadratic_expression.py
@@ -60,11 +60,10 @@ class QuadraticExpression(HasQuadraticProgram):
             j = self.quadratic_program.variables_index[j]
         return self.coefficients[i, j]
 
-    def _coeffs_to_dok_matrix(self,
-                              coefficients: Union[ndarray, spmatrix, List[List[float]],
-                                                  Dict[
-                                                      Tuple[Union[int, str], Union[int, str]],
-                                                      float]]) -> dok_matrix:
+    def _coeffs_to_dok_matrix(
+            self, coefficients: Union[ndarray, spmatrix, List[List[float]],
+                                      Dict[Tuple[Union[int, str], Union[int, str]], float]]) \
+            -> dok_matrix:
         """Maps given coefficients to a dok_matrix.
 
         Args:
@@ -86,7 +85,9 @@ class QuadraticExpression(HasQuadraticProgram):
                     i = self.quadratic_program.variables_index[i]
                 if isinstance(j, str):
                     j = self.quadratic_program.variables_index[j]
-                coeffs[i, j] = value
+                if i > j:
+                    i, j = j, i
+                coeffs[i, j] += value
             coefficients = coeffs
         else:
             raise QiskitOptimizationError("Unsupported format for coefficients.")

--- a/test/optimization/test_quadratic_expression.py
+++ b/test/optimization/test_quadratic_expression.py
@@ -37,7 +37,10 @@ class TestQuadraticExpression(QiskitOptimizationTestCase):
         for _ in range(5):
             quadratic_program.continuous_var()
 
-        coefficients_list = [[i * j for i in range(5)] for j in range(5)]
+        coefficients_list = [[0 for _ in range(5)] for _ in range(5)]
+        for i, v in enumerate(coefficients_list):
+            for j, _ in enumerate(v):
+                coefficients_list[min(i, j)][max(i, j)] += i * j
         coefficients_array = np.array(coefficients_list)
         coefficients_dok = dok_matrix(coefficients_list)
         coefficients_dict_int = {(i, j): v for (i, j), v in coefficients_dok.items()}
@@ -62,11 +65,17 @@ class TestQuadraticExpression(QiskitOptimizationTestCase):
         for _ in range(5):
             quadratic_program.continuous_var()
 
-        coefficients = [[i * j for i in range(5)] for j in range(5)]
+        coefficients = [[0 for _ in range(5)] for _ in range(5)]
+        for i, v in enumerate(coefficients):
+            for j, _ in enumerate(v):
+                coefficients[min(i, j)][max(i, j)] += i * j
         quadratic = QuadraticExpression(quadratic_program, coefficients)
         for i, j_v in enumerate(coefficients):
-            for j, v in enumerate(j_v):
-                self.assertEqual(quadratic[i, j], v)
+            for j, _ in enumerate(j_v):
+                if i == j:
+                    self.assertEqual(quadratic[i, j], coefficients[i][j])
+                else:
+                    self.assertEqual(quadratic[i, j], coefficients[i][j] + coefficients[j][i])
 
     def test_setters(self):
         """ test setters. """
@@ -79,7 +88,10 @@ class TestQuadraticExpression(QiskitOptimizationTestCase):
         zeros = np.zeros((n, n))
         quadratic = QuadraticExpression(quadratic_program, zeros)
 
-        coefficients_list = [[i * j for i in range(5)] for j in range(5)]
+        coefficients_list = [[0 for _ in range(5)] for _ in range(5)]
+        for i, v in enumerate(coefficients_list):
+            for j, _ in enumerate(v):
+                coefficients_list[min(i, j)][max(i, j)] += i * j
         coefficients_array = np.array(coefficients_list)
         coefficients_dok = dok_matrix(coefficients_list)
         coefficients_dict_int = {(i, j): v for (i, j), v in coefficients_dok.items()}
@@ -103,7 +115,10 @@ class TestQuadraticExpression(QiskitOptimizationTestCase):
         quadratic_program = QuadraticProgram()
         x = [quadratic_program.continuous_var() for _ in range(5)]
 
-        coefficients_list = [[i * j for i in range(5)] for j in range(5)]
+        coefficients_list = [[0 for _ in range(5)] for _ in range(5)]
+        for i, v in enumerate(coefficients_list):
+            for j, _ in enumerate(v):
+                coefficients_list[min(i, j)][max(i, j)] += i * j
         quadratic = QuadraticExpression(quadratic_program, coefficients_list)
 
         values_list = list(range(len(x)))
@@ -122,6 +137,8 @@ class TestQuadraticExpression(QiskitOptimizationTestCase):
         q_p.binary_var('z')
         quad = QuadraticExpression(q_p, {('x', 'y'): -1, ('y', 'x'): 2, ('z', 'x'): 3})
         self.assertDictEqual(quad.to_dict(use_name=True), {('x', 'y'): 1, ('x', 'z'): 3})
+        self.assertDictEqual(quad.to_dict(symmetric=True, use_name=True),
+                             {('x', 'y'): 0.5, ('y', 'x'): 0.5, ('x', 'z'): 1.5, ('z', 'x'): 1.5})
 
 
 if __name__ == '__main__':

--- a/test/optimization/test_quadratic_expression.py
+++ b/test/optimization/test_quadratic_expression.py
@@ -114,6 +114,15 @@ class TestQuadraticExpression(QiskitOptimizationTestCase):
         for values in [values_list, values_array, values_dict_int, values_dict_str]:
             self.assertEqual(quadratic.evaluate(values), 900)
 
+    def test_symmetric_set(self):
+        """ test symmetric set """
+        q_p = QuadraticProgram()
+        q_p.binary_var('x')
+        q_p.binary_var('y')
+        q_p.binary_var('z')
+        quad = QuadraticExpression(q_p, {('x', 'y'): -1, ('y', 'x'): 2, ('z', 'x'): 3})
+        self.assertDictEqual(quad.to_dict(use_name=True), {('x', 'y'): 1, ('x', 'z'): 3})
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

`QuadraticExpression` applies an implicit conversion of the input into a upper triangle matrix
and allow users to get either upper triangle format or symmetric format.

### Details and comments

- Converts an input into an upper triangle.
- Add `symmetric` option for `to_array` and `to_dict` with `symmetric=False` is default.

